### PR TITLE
Move HAPI FHIR server to port 8081

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .idea
 
 # Binaries
-./nuts-knooppunt
+nuts-knooppunt

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
     image: hapiproject/hapi:latest
     container_name: hapi-fhir-server
     ports:
-      - "8080:8080"
+      - "7050:8080"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Tiny PR for resolving a conflict between the FHIR server running in the docker-compose container and the knooppunt app. They were both using the same port and thus couldn't be started at the same time.