### PR TITLE
40: CI, build commit hash and version number into images

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -1,0 +1,50 @@
+---
+name: 'Build Native Binaries'
+
+on:
+  release:
+    types: [released]
+
+# cancel build action if superseded by new commit on same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  binaries:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [ 'amd64', 'arm64' ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set version params
+        id: version
+        shell: bash
+        run: |
+          echo "git_commit=$(echo ${GITHUB_SHA})" >> $GITHUB_OUTPUT
+          echo "git_branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+          echo "git_version=${{github.event.release.tag_name}}" >> $GITHUB_OUTPUT
+
+      - name: Print version params
+        run: |
+          echo "Commit: ${{ steps.version.outputs.git_commit }}"
+          echo "Branch: ${{ steps.version.outputs.git_branch }}"
+          echo "Version: ${{ steps.version.outputs.git_version }}"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Build
+        run: |
+          GOOS=linux GOARCH=${{ matrix.arch }} go build -o nuts-linux-${{ matrix.arch }}  -ldflags="-w -s -X 'github.com/nuts-foundation/nuts-node/core.GitCommit=${GIT_COMMIT}' -X 'github.com/nuts-foundation/nuts-node/core.GitBranch=${GIT_BRANCH}' -X 'github.com/nuts-foundation/nuts-node/core.GitVersion=${GIT_VERSION}'" -o nuts-linux-${{ matrix.arch }}
+      - name:  Upload binary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} nuts-linux-${{ matrix.arch }}
+          

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -41,10 +41,10 @@ jobs:
 
       - name: Build
         run: |
-          GOOS=linux GOARCH=${{ matrix.arch }} go build -o nuts-linux-${{ matrix.arch }}  -ldflags="-w -s -X 'github.com/nuts-foundation/nuts-node/core.GitCommit=${GIT_COMMIT}' -X 'github.com/nuts-foundation/nuts-node/core.GitBranch=${GIT_BRANCH}' -X 'github.com/nuts-foundation/nuts-node/core.GitVersion=${GIT_VERSION}'" -o nuts-linux-${{ matrix.arch }}
+          GOOS=linux GOARCH=${{ matrix.arch }} go build -o nuts-linux-${{ matrix.arch }}  -ldflags="-w -s -X 'github.com/nuts-foundation/nuts-knooppunt/component/status.GitCommit=${GIT_COMMIT}' -X 'github.com/nuts-foundation/nuts-knooppunt/component/status.GitBranch=${GIT_BRANCH}' -X 'github.com/nuts-foundation/nuts-knooppunt/component/status.GitVersion=${GIT_VERSION}'" -o nuts-knooppunt-linux-${{ matrix.arch }}
       - name:  Upload binary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ github.event.release.tag_name }} nuts-linux-${{ matrix.arch }}
+          gh release upload ${{ github.event.release.tag_name }} nuts-knooppunt-linux-${{ matrix.arch }}
           

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,93 @@
+---
+name: 'Build Docker images'
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+
+# cancel build action if superseded by new commit on same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set version params
+        id: version
+        shell: bash
+        run: |
+          echo "git_commit=$(echo ${GITHUB_SHA})" >> $GITHUB_OUTPUT
+          echo "git_branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+          echo "git_version=$(git name-rev --tags --name-only $(git rev-parse HEAD))" >> $GITHUB_OUTPUT
+
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get-latest-tag
+        with:
+          semver_only: true
+
+      - name: Print version params
+        run: |
+          echo "Commit: ${{ steps.version.outputs.git_commit }}"
+          echo "Branch: ${{ steps.version.outputs.git_branch }}"
+          echo "Version: ${{ steps.version.outputs.git_version }}"
+          echo "Latest tag: ${{ steps.get-latest-tag.outputs.tag }}"
+          echo "This tag: ${{ github.ref }}"
+
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: nutsfoundation/nuts-knooppunt
+          tags: |
+            # generate 'main' tag for the main branch
+            type=ref,event=branch,enable={{is_default_branch}},prefix=
+            # generate 5.2.1 tag
+            type=semver,pattern={{version}}
+          flavor: |
+            latest=${{ steps.version.outputs.git_version == steps.get-latest-tag.outputs.tag }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            GIT_VERSION=${{ steps.version.outputs.git_version }}
+            GIT_COMMIT=${{ steps.version.outputs.git_commit }}
+            GIT_BRANCH=${{ steps.version.outputs.git_branch }}
+
+      - name: Build and push development image
+        if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main'}}
+        uses: docker/build-push-action@v6
+        with:
+          context: development/dev-image
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: nutsfoundation/nuts-knooppunt:dev

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .idea
 
 # Binaries
-./nuts-knooppunt
+/nuts-knooppunt

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG GIT_COMMIT=0
 ARG GIT_BRANCH=main
 ARG GIT_VERSION=undefined
 
-ENV GOPATH /
+ENV GOPATH=/
 
 COPY go.mod .
 COPY go.sum .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM golang:1.24.4-alpine AS builder
 ARG TARGETARCH
 ARG TARGETOS
 
+ARG GIT_COMMIT=0
+ARG GIT_BRANCH=main
+ARG GIT_VERSION=undefined
+
 ENV GOPATH /
 
 COPY go.mod .
@@ -11,7 +15,7 @@ RUN go mod download && go mod verify
 COPY . .
 
 RUN mkdir /app
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /app/bin .
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s -X 'github.com/nuts-foundation/nuts-knooppunt/core.GitCommit=${GIT_COMMIT}' -X 'github.com/nuts-foundation/nuts-knooppunt/core.GitBranch=${GIT_BRANCH}' -X 'github.com/nuts-foundation/nuts-knooppunt/core.GitVersion=${GIT_VERSION}'" -o /app/bin .
 
 # alpine
 FROM alpine:3.22.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,18 +15,18 @@ RUN go mod download && go mod verify
 COPY . .
 
 RUN mkdir /app
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s -X 'github.com/nuts-foundation/nuts-knooppunt/core.GitCommit=${GIT_COMMIT}' -X 'github.com/nuts-foundation/nuts-knooppunt/core.GitBranch=${GIT_BRANCH}' -X 'github.com/nuts-foundation/nuts-knooppunt/core.GitVersion=${GIT_VERSION}'" -o /app/bin .
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s -X 'github.com/nuts-foundation/nuts-knooppunt/component/status.GitCommit=${GIT_COMMIT}' -X 'github.com/nuts-foundation/nuts-knooppunt/component/status.GitBranch=${GIT_BRANCH}' -X 'github.com/nuts-foundation/nuts-knooppunt/component/status.GitVersion=${GIT_VERSION}'" -o /app/bin .
 
 # alpine
 FROM alpine:3.22.0
 RUN apk update \
   && apk add --no-cache \
-             tzdata \
-             curl
+  tzdata \
+  curl
 COPY --from=builder /app/bin /app/bin
 
 HEALTHCHECK --start-period=30s --timeout=5s --interval=10s \
-    CMD curl -f http://localhost:8080/health || exit 1
+  CMD curl -f http://localhost:8080/health || exit 1
 
 RUN adduser -D -H -u 18081 app-usr
 USER 18081:18081

--- a/component/status/build_vars.go
+++ b/component/status/build_vars.go
@@ -1,4 +1,4 @@
-package core
+package status
 
 import (
 	"fmt"

--- a/component/status/component.go
+++ b/component/status/component.go
@@ -31,4 +31,8 @@ func (c Component) RegisterHttpHandlers(mux *http.ServeMux) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("OK"))
 	})
+	mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(BuildInfo()))
+	})
 }

--- a/core/build_vars.go
+++ b/core/build_vars.go
@@ -1,0 +1,44 @@
+package core
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// Hash of the commit the binary was built on
+var GitCommit = "0"
+
+// Version tag the commit is on
+var GitVersion string
+
+// The branch the binary was built from
+var GitBranch = "development"
+
+func Version() string {
+	if GitVersion != "" && GitVersion != "undefined" {
+		return GitVersion
+	}
+	return GitBranch
+}
+
+func OSArch() string {
+	return fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+func BuildInfo() string {
+	b := strings.Builder{}
+	b.WriteString("Git version: ")
+	b.WriteString(Version())
+	b.WriteString("\n")
+
+	b.WriteString("Git commit: ")
+	b.WriteString(GitCommit)
+	b.WriteString("\n")
+
+	b.WriteString("OS/Arch: ")
+	b.WriteString(OSArch())
+	b.WriteString("\n")
+
+	return b.String()
+}


### PR DESCRIPTION
This PR adds build variables to the status component to hold the git commit, branch and version on which the binary/image was built. There is an endpoint on `/version` to get a quick plaintext output of these variables. Closes #40.

It also adds Github Actions for building images and binaries when a version tag is pushed to (in case of images) or when a release is created (in case of binaries).

Some secrets need to be created for the actions to be able to push container images and upload binaries:
* `GITHUB_TOKEN`: token for uploading the binaries to Github
* `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`: token for pushing container images to Dockerhub

Someone with the required rights will need to create and add these before merging.

The images pushed to Dockerhub will follow the same convention as the ones in nuts-node:
* A `dev` image tag will move with every commit to the main branch
* Semver image tags will move with `v*` repo tags