### PR TITLE
Fix/62/codeowners wildcard

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # Documentation on this file format: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
 
 # Implementation team is global code owner for the repository, who will be automatically invited to review any PR.
-* @nuts-foundation/implementatie-gfs
+* @nuts-foundation/implementatie-gfs JorisHeadease


### PR DESCRIPTION
Verified the CODEOWNERS didn't work in another PR (#63). Modified it, creating a new PR to see if it does properly assign now.