### PR TITLE
Remove reference to development Dockerfile in Actions

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -90,7 +90,6 @@ jobs:
         if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main'}}
         uses: docker/build-push-action@v6
         with:
-          context: development/dev-image
           push: true
           platforms: linux/amd64,linux/arm64
           tags: nuts-foundation/nuts-knooppunt:dev


### PR DESCRIPTION
In the build images workflow, there was a reference to a different Dockerfile that is present in nuts-node but has not been discussed for inclusion in nuts-knooppunt. For now, I removed the reference to make the dev builds green, but if that setup is needed later on, we can always put it back in. Fixes #40 (for the last time hopefully)