### PR TITLE
#112: don't run image build as a PR check

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -7,6 +7,11 @@ on:
       - main
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - Dockerfile
 
 # cancel build action if superseded by new commit on same branch
 concurrency:


### PR DESCRIPTION
As discussed on Slack, image building is slow and not that beneficial to check on every PR. If tests pass and the build process does not change, we can assume image building will also be successful. This change makes it so images should only be built for PRs that change the Dockerfile in the project root, building on commit to main and on release is unchanged. Closes #112