### PR TITLE
mCSD Update Client: fix storing meta.source

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,8 @@ services:
       hapi.fhir.allow_cascading_deletes: true
       # Lets the server generate UUIDs for resources instead of integers
       hapi.fhir.server_id_strategy: UUID
+      # Allow storing of meta.source as provided by the client (used by mCSD to reference the originating resource)
+      store_meta_source_information: SOURCE_URI
 
       #
       # Local development properties (not to be used when deploying to test/production)

--- a/test/e2e/harness/hapi.go
+++ b/test/e2e/harness/hapi.go
@@ -23,6 +23,7 @@ func startHAPI(t *testing.T, dockerNetworkName string) *url.URL {
 			"hapi.fhir.partitioning.allow_references_across_partitions": "false",
 			"hapi.fhir.server_id_strategy":                              "UUID",
 			"hapi.fhir.client_id_strategy":                              "ANY",
+			"hapi.fhir.store_meta_source_information":                   "SOURCE_URI",
 		},
 		WaitingFor: wait.ForHTTP("/fhir/DEFAULT/Account"),
 		LogConsumerCfg: &testcontainers.LogConsumerConfig{


### PR DESCRIPTION
The issue was in HAPI FHIR configuration