### PR TITLE
mCSD Update Client: return empty slice in report when no errors or warnings are there, instead of null

### DIFF
--- a/component/mcsd/component.go
+++ b/component/mcsd/component.go
@@ -154,6 +154,13 @@ func (c *Component) update(ctx context.Context) (UpdateReport, error) {
 			log.Ctx(ctx).Err(err).Str("fhir_server", adminDirectory.fhirBaseURL).Msg("mCSD Directory update failed")
 			report.Errors = append(report.Errors, err.Error())
 		}
+		// Return empty slices instead of null ones, makes a nicer REST API
+		if report.Warnings == nil {
+			report.Warnings = []string{}
+		}
+		if report.Errors == nil {
+			report.Errors = []string{}
+		}
 		result[adminDirectory.fhirBaseURL] = report
 	}
 	return result, nil

--- a/component/mcsd/component_test.go
+++ b/component/mcsd/component_test.go
@@ -54,7 +54,9 @@ func TestComponent_update_regression(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, report)
 	assert.Empty(t, report[server.URL].Warnings)
+	assert.NotNil(t, report[server.URL].Warnings, "expected an empty slice")
 	assert.Empty(t, report[server.URL].Errors)
+	assert.NotNil(t, report[server.URL].Errors, "expected an empty slice")
 }
 
 func TestComponent_update(t *testing.T) {


### PR DESCRIPTION
Which is nicer for the client.