### PR TITLE
#134: re-use HAPI FHIR container during end-to-end tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       hapi.fhir.client_id_strategy: ANY
       # Allows for expung operations, handy during development
       hapi.fhir.delete_expunge_enabled: true
-      # hapi.fhir.allow_multiple_delete: true # to allow $expunge on system-level
+      hapi.fhir.allow_multiple_delete: true # to allow $expunge on system-level
       # Adds some default configs to the HAPI web UI for development
       hapi.fhir.tester.local.name: Local Directory
       hapi.fhir.tester.local.server_address: http://localhost:7050/fhir/DEFAULT

--- a/test/e2e/harness/entrypoint.go
+++ b/test/e2e/harness/entrypoint.go
@@ -2,11 +2,14 @@ package harness
 
 import (
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/nuts-foundation/nuts-knooppunt/cmd"
 	"github.com/nuts-foundation/nuts-knooppunt/component/mcsd"
 	"github.com/nuts-foundation/nuts-knooppunt/test/testdata/vectors"
+	"github.com/nuts-foundation/nuts-knooppunt/test/testdata/vectors/care2cure"
+	"github.com/nuts-foundation/nuts-knooppunt/test/testdata/vectors/sunflower"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,6 +25,10 @@ type Details struct {
 
 func Start(t *testing.T) Details {
 	t.Helper()
+
+	// Delay container shutdown to improve container reusability
+	os.Setenv("TESTCONTAINERS_RYUK_RECONNECTION_TIMEOUT", "5m")
+	os.Setenv("TESTCONTAINERS_RYUK_CONNECTION_TIMEOUT", "5m")
 
 	dockerNetwork, err := createDockerNetwork(t)
 	require.NoError(t, err)
@@ -42,15 +49,13 @@ func Start(t *testing.T) Details {
 			},
 		},
 	})
-	care2CureTenant := vectors.HAPITenant{Name: "care2cure-admin", ID: 4}
-	sunflowerTenant := vectors.HAPITenant{Name: "sunflower-admin", ID: 5}
 	return Details{
 		KnooppuntInternalBaseURL: knooppuntInternalURL,
 		MCSDQueryFHIRBaseURL:     testData.Knooppunt.MCSD.QueryFHIRBaseURL,
 		LRZaFHIRBaseURL:          testData.LRZa.FHIRBaseURL,
-		Care2CureFHIRBaseURL:     care2CureTenant.BaseURL(hapiBaseURL),
-		SunflowerFHIRBaseURL:     sunflowerTenant.BaseURL(hapiBaseURL),
-		SunflowerURA:             "00000020",
-		Care2CureURA:             "00000030",
+		SunflowerFHIRBaseURL:     sunflower.HAPITenant().BaseURL(hapiBaseURL),
+		SunflowerURA:             *sunflower.Organization().Identifier[0].Value,
+		Care2CureFHIRBaseURL:     care2cure.HAPITenant().BaseURL(hapiBaseURL),
+		Care2CureURA:             *care2cure.Organization().Identifier[0].Value,
 	}
 }

--- a/test/e2e/harness/hapi.go
+++ b/test/e2e/harness/hapi.go
@@ -1,7 +1,6 @@
 package harness
 
 import (
-	"context"
 	"net/url"
 	"testing"
 
@@ -14,16 +13,19 @@ func startHAPI(t *testing.T, dockerNetworkName string) *url.URL {
 	t.Log("Starting HAPI FHIR server...")
 	ctx := t.Context()
 	req := testcontainers.ContainerRequest{
-		Name:         "fhirstore",
+		Name:         "knooppunt-unittest-fhirstore",
 		Image:        "hapiproject/hapi:v8.2.0-2",
 		ExposedPorts: []string{"8080/tcp"},
-		Networks:     []string{dockerNetworkName},
+		//Networks:     []string{dockerNetworkName},
 		Env: map[string]string{
 			"hapi.fhir.fhir_version":                                    "R4",
 			"hapi.fhir.partitioning.allow_references_across_partitions": "false",
 			"hapi.fhir.server_id_strategy":                              "UUID",
 			"hapi.fhir.client_id_strategy":                              "ANY",
 			"hapi.fhir.store_meta_source_information":                   "SOURCE_URI",
+			// Enable system-wide $expunge operation for test data cleanup
+			"hapi.fhir.delete_expunge_enabled": "true",
+			"hapi.fhir.allow_multiple_delete":  "true",
 		},
 		WaitingFor: wait.ForHTTP("/fhir/DEFAULT/Account"),
 		LogConsumerCfg: &testcontainers.LogConsumerConfig{
@@ -33,13 +35,10 @@ func startHAPI(t *testing.T, dockerNetworkName string) *url.URL {
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
+		Reuse:            true,
 	})
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := container.Terminate(context.Background()); err != nil {
-			panic(err)
-		}
-	})
+
 	endpoint, err := container.Endpoint(ctx, "http")
 	require.NoError(t, err)
 	u, err := url.Parse(endpoint)

--- a/test/testdata/main.go
+++ b/test/testdata/main.go
@@ -20,9 +20,10 @@ func main() {
 	hapiBaseURL, _ := url.Parse(os.Args[2])
 	tenantName := "orgA"
 	if err := createTenant(internalAPI, tenantName); err != nil {
-		panic("Unable to create tenant: " + err.Error())
+		println("Warn: Unable to create tenant: " + err.Error())
+	} else {
+		println("Created tenant:", tenantName)
 	}
-	println("Created tenant:", tenantName)
 
 	println("Loading FHIR testdata into HAPI...")
 	if _, err := vectors.Load(hapiBaseURL); err != nil {

--- a/test/testdata/vectors/care2cure/vectors.go
+++ b/test/testdata/vectors/care2cure/vectors.go
@@ -1,9 +1,17 @@
 package care2cure
 
 import (
+	"github.com/nuts-foundation/nuts-knooppunt/test/testdata/vectors/hapi"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/caramel/to"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 )
+
+func HAPITenant() hapi.Tenant {
+	return hapi.Tenant{
+		Name: "care2cure-admin",
+		ID:   4,
+	}
+}
 
 func Organization() fhir.Organization {
 	return fhir.Organization{

--- a/test/testdata/vectors/entrypoint.go
+++ b/test/testdata/vectors/entrypoint.go
@@ -8,9 +8,12 @@ import (
 
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/nuts-foundation/nuts-knooppunt/test/testdata/vectors/care2cure"
+	"github.com/nuts-foundation/nuts-knooppunt/test/testdata/vectors/hapi"
 	"github.com/nuts-foundation/nuts-knooppunt/test/testdata/vectors/lrza"
 	"github.com/nuts-foundation/nuts-knooppunt/test/testdata/vectors/sunflower"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/caramel"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/caramel/to"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 )
 
 type KnooppuntSystemDetails struct {
@@ -33,31 +36,33 @@ type Details struct {
 
 func Load(hapiBaseURL *url.URL) (*Details, error) {
 	ctx := context.Background()
-	knptMCSDAdminHAPITenant := HAPITenant{
+	knptMCSDAdminHAPITenant := hapi.Tenant{
 		Name: "knpt-mcsd-admin",
 		ID:   1,
 	}
-	knptMCSDQueryHAPITenant := HAPITenant{
+	knptMCSDQueryHAPITenant := hapi.Tenant{
 		Name: "knpt-mcsd-query",
 		ID:   2,
 	}
-	lrzaMCSDAdminHAPITenant := HAPITenant{
-		Name: "lrza-mcsd-admin",
-		ID:   3,
-	}
-	care2CureAdminHAPITenant := HAPITenant{
-		Name: "care2cure-admin",
-		ID:   4,
-	}
-	sunflowerAdminHAPITenant := HAPITenant{
-		Name: "sunflower-admin",
-		ID:   5,
-	}
+	lrzaMCSDAdminHAPITenant := lrza.HAPITenant()
+	care2CureAdminHAPITenant := care2cure.HAPITenant()
+	sunflowerAdminHAPITenant := sunflower.HAPITenant()
 
 	hapiDefaultFHIRClient := fhirclient.New(hapiBaseURL, http.DefaultClient, nil)
 
-	for _, tenant := range []HAPITenant{knptMCSDQueryHAPITenant, knptMCSDAdminHAPITenant, lrzaMCSDAdminHAPITenant, care2CureAdminHAPITenant, sunflowerAdminHAPITenant} {
-		if err := CreateHAPITenant(ctx, tenant, hapiDefaultFHIRClient); err != nil {
+	// Delete all data first
+	_ = hapiDefaultFHIRClient.CreateWithContext(ctx, fhir.Parameters{
+		Parameter: []fhir.ParametersParameter{
+			{
+				Name:         "expungeEverything",
+				ValueBoolean: to.Ptr(true),
+			},
+		},
+	}, nil, fhirclient.AtPath("/$expunge"))
+
+	// Create tenants
+	for _, tenant := range []hapi.Tenant{knptMCSDQueryHAPITenant, knptMCSDAdminHAPITenant, lrzaMCSDAdminHAPITenant, care2CureAdminHAPITenant, sunflowerAdminHAPITenant} {
+		if err := hapi.CreateTenant(ctx, tenant, hapiDefaultFHIRClient); err != nil {
 			return nil, fmt.Errorf("create HAPI tenant: %w", err)
 		}
 	}

--- a/test/testdata/vectors/hapi/hapi.go
+++ b/test/testdata/vectors/hapi/hapi.go
@@ -1,4 +1,4 @@
-package vectors
+package hapi
 
 import (
 	"context"
@@ -10,20 +10,20 @@ import (
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 )
 
-type HAPITenant struct {
+type Tenant struct {
 	Name string
 	ID   int
 }
 
-func (h HAPITenant) BaseURL(hapiServerURL *url.URL) *url.URL {
+func (h Tenant) BaseURL(hapiServerURL *url.URL) *url.URL {
 	return hapiServerURL.JoinPath(h.Name)
 }
 
-func (h HAPITenant) FHIRClient(hapiServerURL *url.URL) fhirclient.Client {
+func (h Tenant) FHIRClient(hapiServerURL *url.URL) fhirclient.Client {
 	return fhirclient.New(h.BaseURL(hapiServerURL), http.DefaultClient, nil)
 }
 
-func CreateHAPITenant(ctx context.Context, details HAPITenant, fhirClient fhirclient.Client) error {
+func CreateTenant(ctx context.Context, details Tenant, fhirClient fhirclient.Client) error {
 	var tenant fhir.Parameters
 	tenant.Parameter = []fhir.ParametersParameter{
 		{

--- a/test/testdata/vectors/lrza/vectors.go
+++ b/test/testdata/vectors/lrza/vectors.go
@@ -3,8 +3,16 @@ package lrza
 import (
 	"net/url"
 
+	"github.com/nuts-foundation/nuts-knooppunt/test/testdata/vectors/hapi"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 )
+
+func HAPITenant() hapi.Tenant {
+	return hapi.Tenant{
+		Name: "lrza-mcsd-admin",
+		ID:   3,
+	}
+}
 
 // Organizations returns all organizations in the LRZa root directory
 func Organizations() []fhir.Organization {

--- a/test/testdata/vectors/sunflower/vectors.go
+++ b/test/testdata/vectors/sunflower/vectors.go
@@ -1,9 +1,17 @@
 package sunflower
 
 import (
+	"github.com/nuts-foundation/nuts-knooppunt/test/testdata/vectors/hapi"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/caramel/to"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 )
+
+func HAPITenant() hapi.Tenant {
+	return hapi.Tenant{
+		Name: "sunflower-admin",
+		ID:   5,
+	}
+}
 
 func Organization() fhir.Organization {
 	return fhir.Organization{


### PR DESCRIPTION
HAPI FHIR is stopped after 5 minutes, so subsequent tests can re-use the instance. It also works for individual test runs.

A disadvantage is that for each started end-to-end test, a Ryuk (container cleanup container) will be started, which won't end for 5 minutes as well. But I think that's a lesser evil.

We can also switch to not using Ryuk at all, but then any container we start during testing will keep running until manually stopped.