### PR TITLE
Decouple HAPI Fhir initialisation from Nuts tenant creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,6 @@ services:
   init:
     image: golang:1.24.4-alpine
     depends_on:
-      knooppunt:
-        condition: service_healthy
       hapi-fhir-healthcheck:
         condition: service_completed_successfully
     volumes:

--- a/test/testdata/main.go
+++ b/test/testdata/main.go
@@ -16,14 +16,16 @@ func main() {
 	if len(os.Args) < 3 {
 		panic("Usage: " + os.Args[0] + " <internal API base path> <HAPI FHIR multitenant base URL>")
 	}
-	internalAPI := os.Args[1]
 	hapiBaseURL, _ := url.Parse(os.Args[2])
-	tenantName := "orgA"
-	if err := createTenant(internalAPI, tenantName); err != nil {
-		println("Warn: Unable to create tenant: " + err.Error())
-	} else {
-		println("Created tenant:", tenantName)
-	}
+
+	// We need another solution for this so we can just load the test data for HAPI FHIR during development
+	//internalAPI := os.Args[1]
+	//tenantName := "orgA"
+	//if err := createTenant(internalAPI, tenantName); err != nil {
+	//	println("Warn: Unable to create tenant: " + err.Error())
+	//} else {
+	//	println("Created tenant:", tenantName)
+	//}
 
 	println("Loading FHIR testdata into HAPI...")
 	if _, err := vectors.Load(hapiBaseURL); err != nil {


### PR DESCRIPTION
During development I would like to run the go application locally and not through the compose setup so that I can use all my developer tools for instrumentation. To do so I would like to be able to start the HAPI server and initialise the tenants which are in the test data.