### PR TITLE
Be able to inspect the admin and query directory through the HAPI Fhir interface

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       hapi.fhir.delete_expunge_enabled: true
       hapi.fhir.allow_multiple_delete: true # to allow $expunge on system-level
       # Adds some default configs to the HAPI web UI for development
-      hapi.fhir.tester.local.name: Local Directory
+      hapi.fhir.tester.local.name: Default Directory
       hapi.fhir.tester.local.server_address: http://localhost:7050/fhir/DEFAULT
       hapi.fhir.tester.local.refuse_to_fetch_third_party_urls: false
       hapi.fhir.tester.local.fhir_version: R4
@@ -89,10 +89,15 @@ services:
       hapi.fhir.tester.lrza.refuse_to_fetch_third_party_urls: false
       hapi.fhir.tester.lrza.fhir_version: R4
 
-      hapi.fhir.tester.orga.name: Org A Directory
-      hapi.fhir.tester.orga.server_address: http://localhost:7050/fhir/OrgA
-      hapi.fhir.tester.orga.refuse_to_fetch_third_party_urls: false
-      hapi.fhir.tester.orga.fhir_version: R4
+      hapi.fhir.tester.admin.name: Local mCSD Admin Directory 
+      hapi.fhir.tester.admin.server_address: http://localhost:7050/fhir/knpt-mcsd-admin
+      hapi.fhir.tester.admin.refuse_to_fetch_third_party_urls: false
+      hapi.fhir.tester.admin.fhir_version: R4
+      
+      hapi.fhir.tester.query.name: Local mCSD Query Directory
+      hapi.fhir.tester.query.server_address: http://localhost:7050/fhir/knpt-mcsd-query
+      hapi.fhir.tester.query.refuse_to_fetch_third_party_urls: false
+      hapi.fhir.tester.query.fhir_version: R4
 
       # Enable partitioning and allow string tenant identifiers
       hapi.fhir.partitioning.allow_references_across_partitions: false


### PR DESCRIPTION
For demo purposes it would be nice to use HAPI Fhir to inspect the admin and query directory through the HAP interface. I've changed the setup in docker compose to be inline with our partition naming so you can use the filtering.