### PR TITLE
Endpoint Connection Screen

### DIFF
--- a/component/mcsdadmin/component.go
+++ b/component/mcsdadmin/component.go
@@ -439,10 +439,16 @@ func connectEndpoint(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
+	endpoints, err := findAll[fhir.Endpoint](client)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	props := struct {
-		ConnectData tmpls.EpConnectProps
+		ConnectData tmpls.EpConnProps
 	}{
-		ConnectData: tmpls.MakeEpConnectProps(organizations),
+		ConnectData: tmpls.MakeEpConnectProps(organizations, endpoints),
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/component/mcsdadmin/component.go
+++ b/component/mcsdadmin/component.go
@@ -80,6 +80,7 @@ func (c Component) RegisterHttpHandlers(mux *http.ServeMux, _ *http.ServeMux) {
 	mux.HandleFunc("GET /mcsdadmin/endpoint/new", newEndpoint)
 	mux.HandleFunc("POST /mcsdadmin/endpoint/new", newEndpointPost)
 	mux.HandleFunc("GET /mcsdadmin/endpoint/connect", connectEndpoint)
+	mux.HandleFunc("PUT /mcsdadmin/endpoint/connect", connectEndpointPut)
 	mux.HandleFunc("GET /mcsdadmin/location", listLocations)
 	mux.HandleFunc("GET /mcsdadmin/location/new", newLocation)
 	mux.HandleFunc("POST /mcsdadmin/location/new", newLocationPost)
@@ -484,7 +485,7 @@ func connectEndpointPut(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var org fhir.Organization
-	orgStrRef := fmt.Sprintf("Organization/{%s}", orgId)
+	orgStrRef := fmt.Sprintf("Organization/%s", orgId)
 	err = client.Read(orgStrRef, org)
 	if err != nil {
 		http.Error(w, "unknown organization_id", http.StatusBadRequest)
@@ -492,7 +493,7 @@ func connectEndpointPut(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var endp fhir.Endpoint
-	epStrRef := fmt.Sprintf("Endpoint/{%s}", endpId)
+	epStrRef := fmt.Sprintf("Endpoint/%s", endpId)
 	err = client.Read(epStrRef, endp)
 	if err != nil {
 		http.Error(w, "unknown endpoint_id", http.StatusBadRequest)

--- a/component/mcsdadmin/component.go
+++ b/component/mcsdadmin/component.go
@@ -476,7 +476,7 @@ func connectEndpointPut(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	checkedStr := r.PostForm.Get("checked")
+	checkedStr := r.PostForm.Get("status")
 	var checked bool
 	if checkedStr == "on" {
 		checked = true
@@ -518,10 +518,11 @@ func connectEndpointPut(w http.ResponseWriter, r *http.Request) {
 			ref := fhir.Reference{
 				Reference: &epStrRef,
 				Type:      to.Ptr("Endpoint"),
+				Display:   endp.Name,
 			}
 			org.Endpoint = append(org.Endpoint, ref)
 			var resOrg fhir.Organization
-			err = client.Update(orgStrRef, org, resOrg)
+			err = client.Update(orgStrRef, org, &resOrg)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
@@ -532,7 +533,7 @@ func connectEndpointPut(w http.ResponseWriter, r *http.Request) {
 		if hasRef == true {
 			org.Endpoint = slices.Delete(org.Endpoint, hasRefIdx, hasRefIdx+1)
 			var resOrg fhir.Organization
-			err = client.Update(epStrRef, org, resOrg)
+			err = client.Update(orgStrRef, org, &resOrg)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return

--- a/component/mcsdadmin/static/css/mcsdadmin.css
+++ b/component/mcsdadmin/static/css/mcsdadmin.css
@@ -32,3 +32,20 @@
 .form-select {
     margin-bottom: 10px;
 }
+
+table.connections {
+    border-collapse: collapse;
+}
+
+table.connections th, td {
+    padding: 0.6em;
+}
+
+th.vertical {
+    vertical-align: bottom;
+}
+
+th.vertical > div {
+    writing-mode: vertical-rl;
+    transform: rotate(190deg) translateX(-20px);
+}

--- a/component/mcsdadmin/templates/endpoint_connect.html
+++ b/component/mcsdadmin/templates/endpoint_connect.html
@@ -17,12 +17,13 @@
         <th scope="row">{{ .Organization.Name }}</th>
         {{ range .Cells }}
         <td>
-            <input type="text" name="organization_id" value="{{ .Organization.Id }}">
-            <input type="text" name="endpoint_id" value="{{ .Endpoint.Id }}">
+            <input type="hidden" name="organization_id" value="{{ .Organization.Id }}">
+            <input type="hidden" name="endpoint_id" value="{{ .Endpoint.Id }}">
             <input
                     type="checkbox"
                     {{if .Enabled}}checked{{end}}
-                    hx-vals='{"myVal:" "My Value"}'>
+                    hx-put="/mcsdadmin/endpoint/connect"
+                    hx-include="[name='organization_id'], [name='endpoint_id']">
         </td>
         {{ end }}
     </tr>

--- a/component/mcsdadmin/templates/endpoint_connect.html
+++ b/component/mcsdadmin/templates/endpoint_connect.html
@@ -16,7 +16,7 @@
     <tr>
         <th scope="row">{{ .Organization.Name }}</th>
         {{ range .Cells }}
-        <td><input type="checkbox" {{if . }}checked{{end}}></td>
+        <td><input type="checkbox" {{if .Enabled  }}checked{{end}}></td>
         {{ end }}
     </tr>
     {{ end }}

--- a/component/mcsdadmin/templates/endpoint_connect.html
+++ b/component/mcsdadmin/templates/endpoint_connect.html
@@ -1,0 +1,23 @@
+{{define "main"}}
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h2>Connect Endpoints</h2>
+</div>
+{{ with .ConnectData }}
+<table>
+    <thead>
+    <tr>
+        {{ range .OrderedEpRefs }}
+        <th scope="col">{{ .Display }}</th>
+        {{ end }}
+    </tr>
+    </thead>
+    <tbody>
+    {{ range .RowData }}
+    <tr>
+        <p>{{ . }}</p>
+    </tr>
+    {{ end }}
+    </tbody>
+</table>
+{{ end }}
+{{end}}

--- a/component/mcsdadmin/templates/endpoint_connect.html
+++ b/component/mcsdadmin/templates/endpoint_connect.html
@@ -16,7 +16,14 @@
     <tr>
         <th scope="row">{{ .Organization.Name }}</th>
         {{ range .Cells }}
-        <td><input type="checkbox" {{if .Enabled  }}checked{{end}}></td>
+        <td>
+            <input type="text" name="organization_id" value="{{ .Organization.Id }}">
+            <input type="text" name="endpoint_id" value="{{ .Endpoint.Id }}">
+            <input
+                    type="checkbox"
+                    {{if .Enabled}}checked{{end}}
+                    hx-vals='{"myVal:" "My Value"}'>
+        </td>
         {{ end }}
     </tr>
     {{ end }}

--- a/component/mcsdadmin/templates/endpoint_connect.html
+++ b/component/mcsdadmin/templates/endpoint_connect.html
@@ -6,8 +6,9 @@
 <table>
     <thead>
     <tr>
+        <th></th>
         {{ range .Endpoints }}
-        <th scope="col">{{ .Address }}</th>
+        <th class="vertical" thscope="col"><div><span>{{ .Address }}</span></div></th>
         {{ end }}
     </tr>
     </thead>

--- a/component/mcsdadmin/templates/endpoint_connect.html
+++ b/component/mcsdadmin/templates/endpoint_connect.html
@@ -6,15 +6,18 @@
 <table>
     <thead>
     <tr>
-        {{ range .OrderedEpRefs }}
-        <th scope="col">{{ .Display }}</th>
+        {{ range .Endpoints }}
+        <th scope="col">{{ .Address }}</th>
         {{ end }}
     </tr>
     </thead>
     <tbody>
-    {{ range .RowData }}
+    {{ range .Rows }}
     <tr>
-        <p>{{ . }}</p>
+        <th scope="row">{{ .Organization.Name }}</th>
+        {{ range .Cells }}
+        <td><input type="checkbox" {{if . }}checked{{end}}></td>
+        {{ end }}
     </tr>
     {{ end }}
     </tbody>

--- a/component/mcsdadmin/templates/endpoint_connect.html
+++ b/component/mcsdadmin/templates/endpoint_connect.html
@@ -12,18 +12,19 @@
     </tr>
     </thead>
     <tbody>
-    {{ range .Rows }}
+    {{ range $ri, $r := .Rows }}
     <tr>
         <th scope="row">{{ .Organization.Name }}</th>
-        {{ range .Cells }}
+        {{ range $ci, $c := .Cells }}
         <td>
-            <input type="hidden" name="organization_id" value="{{ .Organization.Id }}">
-            <input type="hidden" name="endpoint_id" value="{{ .Endpoint.Id }}">
+            <input id="org_id_{{$ri}}_{{$ci}}" type="hidden" name="organization_id" value="{{ $c.Organization.Id }}">
+            <input id="ep_id_{{$ri}}_{{$ci}}" type="hidden" name="endpoint_id" value="{{ $c.Endpoint.Id }}">
             <input
                     type="checkbox"
+                    name="status"
                     {{if .Enabled}}checked{{end}}
                     hx-put="/mcsdadmin/endpoint/connect"
-                    hx-include="[name='organization_id'], [name='endpoint_id']">
+                    hx-include="#org_id_{{$ri}}_{{$ci}}, #ep_id_{{$ri}}_{{$ci}}">
         </td>
         {{ end }}
     </tr>

--- a/component/mcsdadmin/templates/endpoint_list.html
+++ b/component/mcsdadmin/templates/endpoint_list.html
@@ -1,7 +1,10 @@
 {{define "main"}}
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h2>Endpoints</h2>
-    <a href="/mcsdadmin/endpoint/new" class="btn btn-primary">New Endpoint</a>
+    <div>
+        <a href="/mcsdadmin/endpoint/connect" class="btn btn-primary">Connect Organizations</a>
+        <a href="/mcsdadmin/endpoint/new" class="btn btn-primary">New Endpoint</a>
+    </div>
 </div>
 <div class="card">
     <div class="card-body">

--- a/component/mcsdadmin/templates/templates.go
+++ b/component/mcsdadmin/templates/templates.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/nuts-foundation/nuts-knooppunt/lib/coding"
@@ -298,7 +299,22 @@ type EpConnCell struct {
 
 func MakeEpConnectProps(orgs []fhir.Organization, eps []fhir.Endpoint) EpConnProps {
 	out := EpConnProps{}
+
+	slices.SortFunc(orgs, func(a fhir.Organization, b fhir.Organization) int {
+		var strA, strB string
+		if a.Name != nil {
+			strA = *a.Name
+		}
+		if b.Name != nil {
+			strB = *b.Name
+		}
+		return strings.Compare(strA, strB)
+	})
+	slices.SortFunc(eps, func(a fhir.Endpoint, b fhir.Endpoint) int {
+		return strings.Compare(a.Address, b.Address)
+	})
 	out.Endpoints = eps
+
 	out.Rows = make([]EpConnRow, len(orgs))
 	ClmnLen := len(eps)
 

--- a/component/mcsdadmin/templates/templates_test.go
+++ b/component/mcsdadmin/templates/templates_test.go
@@ -1,0 +1,63 @@
+package templates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/caramel/to"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
+)
+
+func TestTemplates_connect_props(t *testing.T) {
+	orgs := []fhir.Organization{
+		{
+			Name: to.Ptr("Example Organisation One"),
+			Endpoint: []fhir.Reference{
+				{
+					Id: to.Ptr("IdOne"),
+				},
+				{
+					Id: to.Ptr("IdTwo"),
+				},
+			},
+		},
+		{
+			Name: to.Ptr("Example Organisation Two"),
+			Endpoint: []fhir.Reference{
+				{
+					Id: to.Ptr("IdOne"),
+				},
+			},
+		},
+		{
+			Name: to.Ptr("Example Organisation Three"),
+			Endpoint: []fhir.Reference{
+				{
+					Id: to.Ptr("IdThree"),
+				},
+			},
+		},
+		{
+			Name: to.Ptr("Example Organisation Three"),
+			Endpoint: []fhir.Reference{
+				{
+					Id: to.Ptr("IdFour"),
+				},
+				{
+					Id: to.Ptr("IdOne"),
+				},
+			},
+		},
+	}
+
+	props := MakeEpConnectProps(orgs)
+	matrix := props.RowData
+	assert.True(t, matrix[0][1])
+	assert.False(t, matrix[0][2])
+	assert.True(t, matrix[1][0])
+	assert.False(t, matrix[1][1])
+	assert.False(t, matrix[2][0])
+	assert.True(t, matrix[2][2])
+	assert.True(t, matrix[3][0])
+	assert.False(t, matrix[3][1])
+}

--- a/component/mcsdadmin/templates/templates_test.go
+++ b/component/mcsdadmin/templates/templates_test.go
@@ -14,10 +14,10 @@ func TestTemplates_connect_props(t *testing.T) {
 			Name: to.Ptr("Example Organisation One"),
 			Endpoint: []fhir.Reference{
 				{
-					Id: to.Ptr("IdOne"),
+					Reference: to.Ptr("Endpoint/1111"),
 				},
 				{
-					Id: to.Ptr("IdTwo"),
+					Reference: to.Ptr("Endpoint/2222"),
 				},
 			},
 		},
@@ -25,7 +25,7 @@ func TestTemplates_connect_props(t *testing.T) {
 			Name: to.Ptr("Example Organisation Two"),
 			Endpoint: []fhir.Reference{
 				{
-					Id: to.Ptr("IdOne"),
+					Reference: to.Ptr("Endpoint/1111"),
 				},
 			},
 		},
@@ -33,7 +33,7 @@ func TestTemplates_connect_props(t *testing.T) {
 			Name: to.Ptr("Example Organisation Three"),
 			Endpoint: []fhir.Reference{
 				{
-					Id: to.Ptr("IdThree"),
+					Reference: to.Ptr("Endpoint/3333"),
 				},
 			},
 		},
@@ -41,23 +41,35 @@ func TestTemplates_connect_props(t *testing.T) {
 			Name: to.Ptr("Example Organisation Three"),
 			Endpoint: []fhir.Reference{
 				{
-					Id: to.Ptr("IdFour"),
+					Reference: to.Ptr("Endpoint/4444"),
 				},
 				{
-					Id: to.Ptr("IdOne"),
+					Reference: to.Ptr("Endpoint/1111"),
 				},
 			},
 		},
 	}
 
-	props := MakeEpConnectProps(orgs)
-	matrix := props.RowData
-	assert.True(t, matrix[0][1])
-	assert.False(t, matrix[0][2])
-	assert.True(t, matrix[1][0])
-	assert.False(t, matrix[1][1])
-	assert.False(t, matrix[2][0])
-	assert.True(t, matrix[2][2])
-	assert.True(t, matrix[3][0])
-	assert.False(t, matrix[3][1])
+	eps := []fhir.Endpoint{
+		{
+			Id: to.Ptr("1111"),
+		},
+		{
+			Id: to.Ptr("2222"),
+		},
+		{
+			Id: to.Ptr("3333"),
+		},
+	}
+
+	props := MakeEpConnectProps(orgs, eps)
+	rows := props.Rows
+	assert.True(t, rows[0].Cells[1].Enabled)
+	assert.False(t, rows[0].Cells[2].Enabled)
+	assert.True(t, rows[1].Cells[0].Enabled)
+	assert.False(t, rows[1].Cells[1].Enabled)
+	assert.False(t, rows[2].Cells[0].Enabled)
+	assert.True(t, rows[2].Cells[2].Enabled)
+	assert.True(t, rows[3].Cells[0].Enabled)
+	assert.False(t, rows[3].Cells[1].Enabled)
 }


### PR DESCRIPTION
This PR introduces a screen for editing the many to many relationship between organisations and endpoints.

You can reach it by pushing the button on top either edit screen.

<img width="451" height="201" alt="Screenshot 2025-09-25 at 13 15 42" src="https://github.com/user-attachments/assets/74b0fa94-9be3-429d-83a7-615531d56670" />

The button will lead to a table with checkboxes that let you enable/disable the relationships.

<img width="362" height="452" alt="Screenshot 2025-09-25 at 13 18 27" src="https://github.com/user-attachments/assets/42b06d18-2117-4c25-b06f-7c69ae9a84db" />

I will address the delete button in a separate PR.