### PR TITLE
Add tenant for patient data

### DIFF
--- a/test/e2e/harness/entrypoint.go
+++ b/test/e2e/harness/entrypoint.go
@@ -59,9 +59,9 @@ func Start(t *testing.T) Details {
 		KnooppuntInternalBaseURL: knooppuntInternalURL,
 		MCSDQueryFHIRBaseURL:     testData.Knooppunt.MCSD.QueryFHIRBaseURL,
 		LRZaFHIRBaseURL:          testData.LRZa.FHIRBaseURL,
-		SunflowerFHIRBaseURL:     sunflower.HAPITenant().BaseURL(hapiBaseURL),
+		SunflowerFHIRBaseURL:     sunflower.AdminHAPITenant().BaseURL(hapiBaseURL),
 		SunflowerURA:             *sunflower.Organization().Identifier[0].Value,
-		Care2CureFHIRBaseURL:     care2cure.HAPITenant().BaseURL(hapiBaseURL),
+		Care2CureFHIRBaseURL:     care2cure.AdminHAPITenant().BaseURL(hapiBaseURL),
 		Care2CureURA:             *care2cure.Organization().Identifier[0].Value,
 		Vectors:                  *testData,
 	}

--- a/test/testdata/vectors/care2cure/vectors.go
+++ b/test/testdata/vectors/care2cure/vectors.go
@@ -6,7 +6,7 @@ import (
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 )
 
-func HAPITenant() hapi.Tenant {
+func AdminHAPITenant() hapi.Tenant {
 	return hapi.Tenant{
 		Name: "care2cure-admin",
 		ID:   4,

--- a/test/testdata/vectors/sunflower/vectors.go
+++ b/test/testdata/vectors/sunflower/vectors.go
@@ -6,10 +6,17 @@ import (
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 )
 
-func HAPITenant() hapi.Tenant {
+func AdminHAPITenant() hapi.Tenant {
 	return hapi.Tenant{
 		Name: "sunflower-admin",
 		ID:   5,
+	}
+}
+
+func PatientsHAPITenant() hapi.Tenant {
+	return hapi.Tenant{
+		Name: "sunflower-patients",
+		ID:   7,
 	}
 }
 
@@ -55,11 +62,39 @@ func Endpoints() []fhir.Endpoint {
 	}
 }
 
-func Resources() []fhir.HasId {
+func Patients() []fhir.Patient {
+	return []fhir.Patient{
+		{
+			Id: to.Ptr("e9772fee-ecfb-41c2-83a2-51e833d43347"),
+			Identifier: []fhir.Identifier{
+				{
+					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/bsn"),
+					Value:  to.Ptr("999992193"),
+				},
+			},
+			Name: []fhir.HumanName{
+				{
+					Given:  []string{"Jan"},
+					Family: to.Ptr("Jansen"),
+				},
+			},
+		},
+	}
+}
+
+func AdminResources() []fhir.HasId {
 	var resources []fhir.HasId
 	for _, endpoint := range Endpoints() {
 		resources = append(resources, to.Ptr(endpoint))
 	}
 	resources = append(resources, to.Ptr(Organization()))
+	return resources
+}
+
+func PatientsResources() []fhir.HasId {
+	var resources []fhir.HasId
+	for _, patient := range Patients() {
+		resources = append(resources, to.Ptr(patient))
+	}
 	return resources
 }


### PR DESCRIPTION
This PR introduces a `Patients` tenant in the test data for the Sunflower organisation. That tenant contains the patient data.