### PR TITLE
Cleanup deployment docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,12 @@
+# Architecture
+This document details the inner design of the Knooppunt.
+
+![structurizr-GF_SystemContext.svg](images/structurizr-GF_SystemContext.svg)
+
+## Addressing
+
+![structurizr-GF_Addressing_ComponentDiagram.svg](images/structurizr-GF_Addressing_ComponentDiagram.svg)
+
+## Localization
+
+![structurizr-GF_Localization_ComponentDiagram.svg](images/structurizr-GF_Localization_ComponentDiagram.svg)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -7,20 +7,12 @@ The diagrams on this page were created using [Structurizr](https://structurizr.c
 ## Overview
 
 ![structurizr-GF_SystemContext.svg](images/structurizr-GF_SystemContext.svg)
-![structurizr-A1_SystemContext.png](images/structurizr-A1_SystemContext.png)
 
 ### GF Addressing
 ![structurizr-GF_Addressing_ContainerDiagram.svg](images/structurizr-GF_Addressing_ContainerDiagram.svg)
 
-#### Components
-![structurizr-GF_Addressing_ComponentDiagram.svg](images/structurizr-GF_Addressing_ComponentDiagram.svg)
-
 ### GF Localization
 ![structurizr-GF_Localization_ContainerDiagram.svg](images/structurizr-GF_Localization_ContainerDiagram.svg)
-
-#### Components
-
-![structurizr-GF_Localization_ComponentDiagram.svg](images/structurizr-GF_Localization_ComponentDiagram.svg)
 
 ### Technology
 
@@ -31,27 +23,11 @@ Refer to the Nuts node documentation for details on how to set up and configure 
 
 The Knooppunt requires a FHIR server for the mCSD Directories, you can use HAPI FHIR server for this.
 
-## Deployment variants
-
-This chapter describes several supported deployment options. There is a base deployment (version "A"),
-and two variants (versions "B" and "C") that are intended for vendors who want to build on existing systems.
-
-### Deployment "A"
-Embedded Nuts node, "new" mCSD Query and Administration directories in the form of a HAPI FHIR server.
-The vendor uses either the embedded mCSD Admin (web-)Application or the mCSD Administration Directory FHIR API to manage the mCSD entries.
-
-### Deployment "B"
-A variant of version "A" that uses an mCSD Administration Directory that is not managed through the embedded mCSD Admin (web-)Application.
-This is often a facade on an existing care organization/endpoint database or API.
-
-Intended for: vendors that have an existing system to administer care organization/endpoint information.
-
-### Deployment "C"
-A variant of version "A" that uses an existing Nuts node, instead of the embedded Nuts node.
-
 ## Generic Functions
 
 This chapter describes when/how to deploy specific generic functions of the Knooppunt.
+
+See [CONFIGURATION.md](./CONFIGURATION.md) for detailed configuration options.
 
 ### Addressing
 
@@ -81,14 +57,35 @@ root directory.
 For testing purposes your admin directory should be reachable through the public internet. The production scenario aims
 to utilise mTLS for trusted communication.
 
-For full configuration options see our [Configuration Guide](./CONFIGURATION.md)
+#### Using the mCSD Administration Application
+
+The Knooppunt contains a web-application to manually manage the mCSD Administration Directory entries (e.g. create organizations and endpoints).
+This web-application uses the mCSD Administration Directory FHIR API to create/update/delete these resources.
+
+Set [`mcsdadmin.fhirbaseurl`](./CONFIGURATION.md) to the FHIR base URL of the mCSD Administration Directory to use the embedded mCSD Admin (web-)Application.
+
+> **_NOTE:_**
+> Alternatively, the vendor can choose to manage the mCSD Administration Directory outside the Knooppunt,
+> for example through an existing care organization/endpoint database or API.
+>
+> Examples when a vendor doesn't manage the mCSD Administration Directory through the embedded mCSD Admin (web-)Application include:
+> - the vendor manages its mCSD information directly in a database (e.g. an SQL database)
+> - the vendor syncs its mCSD information from another system (e.g. an ERP system) to the mCSD Administration Directory
 
 ### Localization
 
-To enable the NVI-endpoint of the Knooppunt, you need to provide a base URL for the NVI service.
+To enable the NVI-endpoint of the Knooppunt, you need to provide a base URL for the NVI service, as provided by the ministry of health (VWS).
 
-The NVI will be provided by the ministry of health (VWS). During preliminary testing, an example NVI is available on this URL:
+Set [`nvi.baseurl`](./CONFIGURATION.md) to the base URL of the NVI service.
 
-```
-https://knooppunt-test.nuts-services.nl/nvi
-```
+> **_NOTE:_** During preliminary testing, an example NVI is available on this URL:
+>    ```
+>    https://knooppunt-test.nuts-services.nl/nvi
+>    ```
+
+### Authentication
+
+The Knooppunt can be deployed with an embedded Nuts node. If a vendor has an existing Nuts node,
+or wants to have the Nuts node deployed separately, the Knooppunt can use that Nuts node instead.
+
+Use [`nuts.enabled`](./CONFIGURATION.md) to configure the embedded or existing Nuts node.


### PR DESCRIPTION
Make deployment docs more relevant to the vendor:
- Rewrote deployment variants (Nuts node embedded/not, managing mCSD through admin app). Moved these to the GF functions section
- Added "Authentication" GF function, referring to Nuts
- Moved component diagrams to separate "ARCHITECTURE.md" document, since those are aimed at Knooppunt developers