### PR TITLE
Fix bug that prevents posting endpoints

### DIFF
--- a/component/mcsdadmin/component.go
+++ b/component/mcsdadmin/component.go
@@ -449,7 +449,7 @@ func newEndpointPost(w http.ResponseWriter, r *http.Request) {
 	}
 	endpoint.Address = address
 
-	if len(r.PostForm["payload-types"]) < 1 {
+	if len(r.PostForm["payload-type"]) < 1 {
 		badRequest(w, r, "missing payload type")
 		return
 	}


### PR DESCRIPTION
Noticed I was not able to add any more endpoints through the admin. It always says the payload type is missing. This small change fixes it.