### PR TITLE
Fix URL in documentation

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -181,7 +181,7 @@ Set the `notify_endpoint` in your Knooppunt configuration (`knooppunt.yml`):
 
 ```yaml
 mitz:
-  mitzbase: "https://tst-api.mijn-mitz.nl"
+  mitzbase: "https://tst-api.mijn-mitz.nl/tst-us/mitz"
   notify_endpoint: "https://your-platform.example.com/mitz/notify"
   # ... other MITZ settings
 ```


### PR DESCRIPTION
As reported by Formelio, the URL in the documentation should be:

`https://tst-api.mijn-mitz.nl/tst-us/mitz