### PR TITLE
(PDP) Check for Resource ID Removed

### DIFF
--- a/component/pdp/component.go
+++ b/component/pdp/component.go
@@ -160,7 +160,6 @@ func validateInput(input MainPolicyInput) bool {
 		input.DataHolderOrganizationUra,
 		input.DataHolderFacilityType,
 		input.PurposeOfUse,
-		input.ResourceId,
 		input.ResourceType,
 	}
 	if slices.Contains(requiredValues, "") {


### PR DESCRIPTION
This check prevents us doing search requests while requesting data from the PEP. It only allows read requests.