### PR TITLE
PEP Configured to Accept Nuts Access Token

### DIFF
--- a/pep/nginx/conf.d/knooppunt.conf
+++ b/pep/nginx/conf.d/knooppunt.conf
@@ -15,6 +15,12 @@ upstream knooppunt_pdp {
     keepalive 32;
 }
 
+# Upstream for Nuts introspection`
+upstream nuts_introspect {
+    server ${NUTS_INTROSPECTION_HOST};
+    keepalive 32;
+}
+
 server {
     listen 8080 default_server;
     server_name _;
@@ -83,6 +89,21 @@ server {
         proxy_pass http://knooppunt_pdp/pdp/v1/data/knooppunt/authz;
         proxy_method POST;
         proxy_set_header Content-Type "application/json";
+        proxy_pass_request_body on;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 10s;
+        proxy_read_timeout 10s;
+    }
+
+    # Internal endpoint to call nuts introspection
+    # OPA standard: POST /v1/data/{package}/{rule}
+    location = /_nuts {
+        internal;
+        proxy_pass http://nuts_introspect/internal/auth/v2/accesstoken/introspect;
+        proxy_method POST;
+        proxy_set_header Content-Type "application/x-www-form-urlencoded";
         proxy_pass_request_body on;
         proxy_http_version 1.1;
         proxy_set_header Connection "";


### PR DESCRIPTION
This is an update to mock access token to accept nuts access token like this `fauodb0ok3wH2-jIHai7w1kB5HTuUrLUXA5y7PGx3Ks-00000023-01.015-123456789-900203638`. This is a draft PR that is opened for to be an example.