### PR TITLE
chore: bump Helm chart and appVersion for `nuts-knooppunt` to 0.3.1

### DIFF
--- a/helm/nuts-knooppunt/Chart.yaml
+++ b/helm/nuts-knooppunt/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "0.3.1"
 
 dependencies:
   - name: fhir

--- a/helm/nuts-knooppunt/values.yaml
+++ b/helm/nuts-knooppunt/values.yaml
@@ -11,7 +11,7 @@ image:
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.2.0"
+  tag: "0.3.1"
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []


### PR DESCRIPTION
Chart version > 0.1.2 > 0.1.3 
App version > now matches tag: 0.3.1
image.tag = 0.3.1