### PR TITLE
fix: add missing NVI_TENANT environment variable to e2e test HAPI container

### DIFF
--- a/test/e2e/harness/hapi.go
+++ b/test/e2e/harness/hapi.go
@@ -27,6 +27,7 @@ func startHAPI(t *testing.T, dockerNetworkName string) *url.URL {
 			"hapi.fhir.delete_expunge_enabled": "true",
 			"hapi.fhir.allow_multiple_delete":  "true",
 			"NVI_AUDIENCE":                     "nvi",
+			"NVI_TENANT":                       "nvi",
 		},
 		WaitingFor: wait.ForHTTP("/fhir/DEFAULT/Account"),
 		LogConsumerCfg: &testcontainers.LogConsumerConfig{


### PR DESCRIPTION
  ## Summary
  Adds the missing `NVI_TENANT` environment variable to the e2e test HAPI FHIR container configuration, aligning it with the docker-compose.yml setup.

  ## Problem
  The e2e NVI tests were failing with partition validation errors:
  Partition name "nvi" is not valid

  This occurred because the fake-nvi HAPI FHIR server requires both `NVI_AUDIENCE` and `NVI_TENANT` environment variables to properly configure and validate the NVI partition.

  ## Root Cause
  In commit #97e6bc4, when the fake-nvi Docker image was introduced:
  - Both `NVI_AUDIENCE` and `NVI_TENANT` were added to `docker-compose.yml`
  - Only `NVI_AUDIENCE` was added to the test harness (`test/e2e/harness/hapi.go`)
  - This created a configuration inconsistency between local development and e2e test environments

  ## Solution
  This PR adds `NVI_TENANT: nvi` to the e2e test harness HAPI container configuration, ensuring:
  - Consistent configuration between docker-compose and e2e tests
  - Proper NVI partition validation in the fake-nvi HAPI server
  - Reliable test execution without intermittent failures

  ## Testing
  - [x] NVI e2e tests pass with this change
  - [x] Configuration matches docker-compose.yml setup

  ## Related
  - Addresses configuration gap from #243 (NVI: use actual Fake NVI HAPI interceptor in e2e test)