### PR TITLE
 fix(mock-vc-issuer): use shared getIssuerHostname utility in homepage

### DIFF
--- a/mock-components/vc-issuer/app/page.tsx
+++ b/mock-components/vc-issuer/app/page.tsx
@@ -1,6 +1,10 @@
+import { getIssuerHostname } from '@/lib/utils';
+
+export const dynamic = 'force-dynamic';
+
 export default function Home() {
   // Derive base URL from ISSUER_HOSTNAME (the single source of truth)
-  const hostname = process.env.ISSUER_HOSTNAME || 'localhost:3000';
+  const hostname = getIssuerHostname();
   const isLocalhost = hostname.startsWith('localhost');
   const protocol = isLocalhost ? 'http' : 'https';
   const baseUrl = `${protocol}://${hostname}`;


### PR DESCRIPTION
 ## Summary
  - Refactor homepage to use shared `getIssuerHostname()` utility instead of inline env var access
  - Add `force-dynamic` export to ensure environment variables are read at runtime

  ## Changes
  - **app/page.tsx**: Import and use `getIssuerHostname()` from `@/lib/utils` for consistent hostname resolution across the application

  ## Why
  Centralizes hostname resolution logic in a single utility function, making it easier to maintain and ensuring consistent behavior across all components.
