### PR TITLE
#290: validating child organization and extensive testing of authoritative checks

### DIFF
--- a/component/mcsd/validator.go
+++ b/component/mcsd/validator.go
@@ -21,7 +21,7 @@ type ValidationRules struct {
 // ValidateParentOrganizations validates all parent organizations in the map.
 func ValidateParentOrganizations(parentOrganizationMap map[*fhir.Organization][]*fhir.Organization) error {
 	for parentOrg := range parentOrganizationMap {
-		if err := validateOrganizationResource(parentOrg); err != nil {
+		if err := validateOrganizationResource(parentOrg, parentOrganizationMap); err != nil {
 			return fmt.Errorf("parent organization failed to validate: %w", err)
 		}
 	}
@@ -47,7 +47,7 @@ func ValidateUpdate(ctx context.Context, rules ValidationRules, resourceJSON []b
 
 	switch resourceType {
 	case "Organization":
-		return unmarshalAndVisitOrganizationResource(resourceJSON)
+		return unmarshalAndVisitOrganizationResource(resourceJSON, parentOrganizationMap)
 	case "Location":
 		return unmarshalAndVisitResource[fhir.Location](ctx, resourceJSON, parentOrganizationMap, validateLocationResource)
 	case "PractitionerRole":
@@ -68,31 +68,124 @@ func unmarshalAndVisitResource[ResType any](ctx context.Context, resourceJSON []
 	return visitor(ctx, resource, parentOrganizationMap)
 }
 
-func unmarshalAndVisitOrganizationResource(resourceJSON []byte) error {
+func unmarshalAndVisitOrganizationResource(resourceJSON []byte, parentOrganizationMap map[*fhir.Organization][]*fhir.Organization) error {
 	resource := new(fhir.Organization)
 	if err := json.Unmarshal(resourceJSON, resource); err != nil {
 		return fmt.Errorf("failed to unmarshal resource JSON: %w", err)
 	}
-	return validateOrganizationResource(resource)
+	return validateOrganizationResource(resource, parentOrganizationMap)
 }
 
-func validateOrganizationResource(resource *fhir.Organization) error {
+func validateOrganizationResource(resource *fhir.Organization, parentOrganizationMap map[*fhir.Organization][]*fhir.Organization) error {
 	if resource == nil {
 		return nil // No validation needed if resource is nil
 	}
 
 	uraIdentifiers := fhirutil.FilterIdentifiersBySystem(resource.Identifier, coding.URANamingSystem)
 	if len(uraIdentifiers) > 1 {
+		// Only the authoritative organization should have a URA identifier, and only one
 		slog.Warn("Organization has multiple URA identifiers", slog.String("system", coding.URANamingSystem), slog.Int("count", len(uraIdentifiers)))
 		return fmt.Errorf("organization can't have multiple identifiers with system %s", coding.URANamingSystem)
 	}
 
-	if len(uraIdentifiers) == 0 && resource.PartOf == nil {
-		slog.Warn("Organization missing URA identifier and partOf reference", slog.String("system", coding.URANamingSystem))
-		return fmt.Errorf("organization must have an identifier with system %s or refer to another organization through 'partOf'", coding.URANamingSystem)
+	// Collect all URA identifiers from parent organizations
+	parentURAIdentifiers := make(map[string]bool)
+	for parentOrg := range parentOrganizationMap {
+		if parentOrg != nil {
+			parentURAs := fhirutil.FilterIdentifiersBySystem(parentOrg.Identifier, coding.URANamingSystem)
+			for _, ura := range parentURAs {
+				if ura.Value != nil {
+					parentURAIdentifiers[*ura.Value] = true
+				}
+			}
+		}
+	}
+
+	if len(uraIdentifiers) > 0 {
+		// If the resource has a URA identifier, it must match one from the parent organizations
+		resourceURA := uraIdentifiers[0]
+		if resourceURA.Value == nil {
+			return fmt.Errorf("organization has a URA identifier with no value")
+		}
+		if !parentURAIdentifiers[*resourceURA.Value] {
+			slog.Warn("Organization URA identifier does not match any parent organization URA", slog.String("ura", *resourceURA.Value))
+			return fmt.Errorf("organization's URA identifier must match one of the authoritative parent organizations")
+		}
+	}
+
+	if len(uraIdentifiers) == 0 {
+		if resource.PartOf == nil {
+			slog.Warn("Organization missing URA identifier and partOf reference", slog.String("system", coding.URANamingSystem))
+			return fmt.Errorf("organization must have an identifier with system %s or refer to another organization through 'partOf'", coding.URANamingSystem)
+		}
+
+		// Validate that partOf references an authoritative organization (one with a URA identifier)
+		if err := validatePartOfReferencesAuthoritativeOrg(resource.PartOf, parentOrganizationMap); err != nil {
+			return err
+		}
 	}
 
 	return nil
+}
+
+// validatePartOfReferencesAuthoritativeOrg validates that the partOf reference eventually points to an organization with a URA identifier
+// by recursively following the partOf chain up the organization tree
+func validatePartOfReferencesAuthoritativeOrg(partOfRef *fhir.Reference, parentOrganizationMap map[*fhir.Organization][]*fhir.Organization) error {
+	if partOfRef == nil {
+		return nil
+	}
+
+	visited := make(map[string]bool)
+	return validatePartOfChain(partOfRef, parentOrganizationMap, visited)
+}
+
+// validatePartOfChain recursively validates the partOf chain until it finds an organization with a URA identifier
+func validatePartOfChain(partOfRef *fhir.Reference, parentOrganizationMap map[*fhir.Organization][]*fhir.Organization, visited map[string]bool) error {
+	if partOfRef == nil {
+		return fmt.Errorf("reached end of partOf chain without finding an authoritative organization")
+	}
+
+	refID := extractReferenceID(partOfRef.Reference)
+	if refID == "" {
+		return fmt.Errorf("partOf reference does not contain a valid ID")
+	}
+
+	// Check for circular references
+	if visited[refID] {
+		return fmt.Errorf("circular reference detected in partOf chain at organization %s", refID)
+	}
+	visited[refID] = true
+
+	// Search for the referenced organization in the parent organization map
+	for parentOrg := range parentOrganizationMap {
+		if parentOrg != nil && parentOrg.Id != nil && *parentOrg.Id == refID {
+			// Check if this organization has a URA identifier (is authoritative)
+			uraIdentifiers := fhirutil.FilterIdentifiersBySystem(parentOrg.Identifier, coding.URANamingSystem)
+			if len(uraIdentifiers) > 0 {
+				return nil // Found an authoritative organization
+			}
+			// No URA identifier, follow the partOf chain
+			return validatePartOfChain(parentOrg.PartOf, parentOrganizationMap, visited)
+		}
+
+		// Also check in the allOrganizations list
+		allOrganizations := parentOrganizationMap[parentOrg]
+		for _, org := range allOrganizations {
+			if org != nil && org.Id != nil && *org.Id == refID {
+				// Check if this organization has a URA identifier (is authoritative)
+				uraIdentifiers := fhirutil.FilterIdentifiersBySystem(org.Identifier, coding.URANamingSystem)
+				if len(uraIdentifiers) > 0 {
+					return nil // Found an authoritative organization
+				}
+				// No URA identifier, follow the partOf chain
+				return validatePartOfChain(org.PartOf, parentOrganizationMap, visited)
+			}
+		}
+	}
+
+	// Referenced organization not found in parent organization map
+	slog.Warn("Organization partOf reference not found in parent organization map", slog.String("refID", refID))
+	return fmt.Errorf("organization's partOf reference could not be validated (organization %s not found within authoritative organizations)", refID)
 }
 
 func validateHealthcareServiceResource(ctx context.Context, resource *fhir.HealthcareService, parentOrganizationMap map[*fhir.Organization][]*fhir.Organization) error {

--- a/component/mcsd/validator_test.go
+++ b/component/mcsd/validator_test.go
@@ -8,40 +8,6 @@ import (
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 )
 
-// Test that the generic validators do their job. At this point, this only checks whether
-// the resource is of an allowed type before deferring to a resource-specific function.
-func TestGenericValidators(t *testing.T) {
-	resources := []struct {
-		name         string
-		resourceJSON []byte
-		valid        bool
-	}{
-		{
-			name:         "valid Organization",
-			resourceJSON: []byte(`{"resourceType":"Organization", "identifier":[{"system":"http://fhir.nl/fhir/NamingSystem/ura","value":"12345"}]}`),
-			valid:        true,
-		},
-		{
-			name:         "invalid resource type",
-			resourceJSON: []byte(`{"resourceType":"Patient"}`),
-			valid:        false,
-		},
-	}
-
-	for _, tt := range resources {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateUpdate(t.Context(), ValidationRules{AllowedResourceTypes: []string{"Organization"}}, tt.resourceJSON, make(map[*fhir.Organization][]*fhir.Organization))
-
-			if tt.valid {
-				require.NoError(t, err)
-			} else {
-				require.Error(t, err)
-			}
-		})
-	}
-
-}
-
 // Test validator for Organization resources. An organization should either have an URA number
 // or should be a sub-organization to an Organization with an URA number.
 //
@@ -117,13 +83,1610 @@ func TestOrganizationValidator(t *testing.T) {
 
 	for _, tt := range organizations {
 		t.Run(tt.name, func(t *testing.T) {
-			// Test with no parent organization (expects organization to have its own URA or no partOf)
-			err := validateOrganizationResource(&tt.organization)
+			// Create a parent organization map with the organization having a matching URA
+			parentOrgMap := make(map[*fhir.Organization][]*fhir.Organization)
+			if len(tt.organization.Identifier) > 0 {
+				// Add a parent org with the same URA for validation
+				parentOrg := &fhir.Organization{
+					Id:         to.Ptr("parent-org"),
+					Identifier: tt.organization.Identifier,
+				}
+				parentOrgMap[parentOrg] = []*fhir.Organization{}
+			}
+
+			err := validateOrganizationResource(&tt.organization, parentOrgMap)
 
 			if tt.valid {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateOrganizationResource_URAValidation(t *testing.T) {
+	uraSystem := "http://fhir.nl/fhir/NamingSystem/ura"
+
+	tests := []struct {
+		name          string
+		organization  *fhir.Organization
+		parentOrgMap  map[*fhir.Organization][]*fhir.Organization
+		shouldSucceed bool
+		description   string
+	}{
+		{
+			name: "organization with URA matching parent org",
+			organization: &fhir.Organization{
+				Id: to.Ptr("org-1"),
+				Identifier: []fhir.Identifier{
+					{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+				},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("parent-org"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when organization URA matches parent organization URA",
+		},
+		{
+			name: "organization with URA not matching any parent org",
+			organization: &fhir.Organization{
+				Id: to.Ptr("org-1"),
+				Identifier: []fhir.Identifier{
+					{System: to.Ptr(uraSystem), Value: to.Ptr("99999")},
+				},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("parent-org"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: false,
+			description:   "should fail when organization URA does not match any parent organization URA",
+		},
+		{
+			name: "organization with URA matching one of multiple parent orgs",
+			organization: &fhir.Organization{
+				Id: to.Ptr("org-1"),
+				Identifier: []fhir.Identifier{
+					{System: to.Ptr(uraSystem), Value: to.Ptr("67890")},
+				},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("parent-org-1"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+				{
+					Id: to.Ptr("parent-org-2"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("67890")},
+					},
+				}: {},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when organization URA matches one of multiple parent organizations",
+		},
+		{
+			name: "organization with multiple URA identifiers",
+			organization: &fhir.Organization{
+				Id: to.Ptr("org-1"),
+				Identifier: []fhir.Identifier{
+					{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					{System: to.Ptr(uraSystem), Value: to.Ptr("67890")},
+				},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("parent-org"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: false,
+			description:   "should fail when organization has multiple URA identifiers",
+		},
+		{
+			name: "organization with no URA and no partOf",
+			organization: &fhir.Organization{
+				Id: to.Ptr("org-1"),
+				Identifier: []fhir.Identifier{
+					{System: to.Ptr("http://other-system.nl"), Value: to.Ptr("12345")},
+				},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("parent-org"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: false,
+			description:   "should fail when organization has no URA identifier and no partOf reference",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOrganizationResource(tt.organization, tt.parentOrgMap)
+
+			if tt.shouldSucceed {
+				require.NoError(t, err, tt.description)
+			} else {
+				require.Error(t, err, tt.description)
+			}
+		})
+	}
+}
+
+func TestValidateOrganizationResource_PartOfChainValidation(t *testing.T) {
+	uraSystem := "http://fhir.nl/fhir/NamingSystem/ura"
+
+	tests := []struct {
+		name          string
+		organization  *fhir.Organization
+		parentOrgMap  map[*fhir.Organization][]*fhir.Organization
+		shouldSucceed bool
+		description   string
+	}{
+		{
+			name: "organization with no URA but valid partOf to org with URA",
+			organization: &fhir.Organization{
+				Id:     to.Ptr("child-org"),
+				PartOf: &fhir.Reference{Reference: to.Ptr("Organization/parent-org")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("parent-org"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when organization has no URA but partOf points to org with URA",
+		},
+		{
+			name: "two-level partOf chain: orgC -> orgB -> orgA (only orgA has URA)",
+			organization: &fhir.Organization{
+				Id:     to.Ptr("org-c"),
+				PartOf: &fhir.Reference{Reference: to.Ptr("Organization/org-b")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("org-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("org-b"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/org-a")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when partOf chain eventually leads to org with URA (2 levels)",
+		},
+		{
+			name: "three-level partOf chain: orgD -> orgC -> orgB -> orgA (only orgA has URA)",
+			organization: &fhir.Organization{
+				Id:     to.Ptr("org-d"),
+				PartOf: &fhir.Reference{Reference: to.Ptr("Organization/org-c")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("org-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("org-b"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/org-a")},
+					},
+					{
+						Id:     to.Ptr("org-c"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/org-b")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when partOf chain eventually leads to org with URA (3 levels)",
+		},
+		{
+			name: "partOf chain ends without URA",
+			organization: &fhir.Organization{
+				Id:     to.Ptr("org-c"),
+				PartOf: &fhir.Reference{Reference: to.Ptr("Organization/org-b")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("org-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr("http://other-system.nl"), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("org-b"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/org-a")},
+					},
+				},
+			},
+			shouldSucceed: false,
+			description:   "should fail when partOf chain ends at org without URA",
+		},
+		{
+			name: "partOf references non-existent organization",
+			organization: &fhir.Organization{
+				Id:     to.Ptr("org-c"),
+				PartOf: &fhir.Reference{Reference: to.Ptr("Organization/non-existent")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("org-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: false,
+			description:   "should fail when partOf references an organization not in the map",
+		},
+		{
+			name: "circular reference in partOf chain: orgB -> orgC -> orgB",
+			organization: &fhir.Organization{
+				Id:     to.Ptr("org-b"),
+				PartOf: &fhir.Reference{Reference: to.Ptr("Organization/org-c")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("org-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("org-c"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/org-b")},
+					},
+				},
+			},
+			shouldSucceed: false,
+			description:   "should fail when circular reference is detected in partOf chain",
+		},
+		{
+			name: "partOf chain with no further references",
+			organization: &fhir.Organization{
+				Id:     to.Ptr("org-c"),
+				PartOf: &fhir.Reference{Reference: to.Ptr("Organization/org-b")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("org-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id: to.Ptr("org-b"),
+						// No partOf and no URA
+					},
+				},
+			},
+			shouldSucceed: false,
+			description:   "should fail when partOf chain ends at org with no URA and no further partOf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOrganizationResource(tt.organization, tt.parentOrgMap)
+
+			if tt.shouldSucceed {
+				require.NoError(t, err, tt.description)
+			} else {
+				require.Error(t, err, tt.description)
+			}
+		})
+	}
+}
+
+func TestValidateOrganizationResource_ComplexTrees(t *testing.T) {
+	uraSystem := "http://fhir.nl/fhir/NamingSystem/ura"
+
+	tests := []struct {
+		name          string
+		organization  *fhir.Organization
+		parentOrgMap  map[*fhir.Organization][]*fhir.Organization
+		shouldSucceed bool
+		description   string
+	}{
+		{
+			name: "complex tree: hospital with multiple departments",
+			organization: &fhir.Organization{
+				Id:     to.Ptr("cardiology-dept"),
+				PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("emergency-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("surgery-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed for department in hospital tree structure",
+		},
+		{
+			name: "complex tree: sub-department in department in hospital",
+			organization: &fhir.Organization{
+				Id:     to.Ptr("icu-cardiology"),
+				PartOf: &fhir.Reference{Reference: to.Ptr("Organization/cardiology-dept")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("cardiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("surgery-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed for sub-department in nested tree structure",
+		},
+		{
+			name: "multiple parent orgs: org belongs to one tree",
+			organization: &fhir.Organization{
+				Id:     to.Ptr("clinic-dept"),
+				PartOf: &fhir.Reference{Reference: to.Ptr("Organization/clinic-a")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("11111")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("hospital-dept-a"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-a")},
+					},
+				},
+				{
+					Id: to.Ptr("clinic-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("22222")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("clinic-dept-b"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/clinic-a")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when org belongs to one of multiple parent organization trees",
+		},
+		{
+			name: "organization with URA belonging to different parent tree",
+			organization: &fhir.Organization{
+				Id: to.Ptr("clinic-dept"),
+				Identifier: []fhir.Identifier{
+					{System: to.Ptr(uraSystem), Value: to.Ptr("11111")},
+				},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("11111")},
+					},
+				}: {},
+				{
+					Id: to.Ptr("clinic-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("22222")},
+					},
+				}: {},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when organization URA matches one of the parent trees",
+		},
+		{
+			name: "deep nested tree (5 levels)",
+			organization: &fhir.Organization{
+				Id:     to.Ptr("org-level-5"),
+				PartOf: &fhir.Reference{Reference: to.Ptr("Organization/org-level-4")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("org-level-1"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("org-level-2"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/org-level-1")},
+					},
+					{
+						Id:     to.Ptr("org-level-3"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/org-level-2")},
+					},
+					{
+						Id:     to.Ptr("org-level-4"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/org-level-3")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed with deep nested tree (5 levels)",
+		},
+		{
+			name: "organization partOf sibling (both under same parent)",
+			organization: &fhir.Organization{
+				Id:     to.Ptr("dept-b"),
+				PartOf: &fhir.Reference{Reference: to.Ptr("Organization/dept-a")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("dept-a"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when org references sibling that has valid parent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOrganizationResource(tt.organization, tt.parentOrgMap)
+
+			if tt.shouldSucceed {
+				require.NoError(t, err, tt.description)
+			} else {
+				require.Error(t, err, tt.description)
+			}
+		})
+	}
+}
+
+func TestValidateOrganizationResource_EdgeCases(t *testing.T) {
+	uraSystem := "http://fhir.nl/fhir/NamingSystem/ura"
+
+	tests := []struct {
+		name          string
+		organization  *fhir.Organization
+		parentOrgMap  map[*fhir.Organization][]*fhir.Organization
+		shouldSucceed bool
+		description   string
+	}{
+		{
+			name:          "nil organization",
+			organization:  nil,
+			parentOrgMap:  map[*fhir.Organization][]*fhir.Organization{},
+			shouldSucceed: true,
+			description:   "should succeed (no validation) when organization is nil",
+		},
+		{
+			name: "empty parent organization map",
+			organization: &fhir.Organization{
+				Id: to.Ptr("org-1"),
+				Identifier: []fhir.Identifier{
+					{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+				},
+			},
+			parentOrgMap:  map[*fhir.Organization][]*fhir.Organization{},
+			shouldSucceed: false,
+			description:   "should fail when parent org map is empty and org has URA",
+		},
+		{
+			name: "organization with empty URA value",
+			organization: &fhir.Organization{
+				Id: to.Ptr("org-1"),
+				Identifier: []fhir.Identifier{
+					{System: to.Ptr(uraSystem), Value: nil},
+				},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("parent-org"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: false,
+			description:   "should fail when organization has URA identifier with nil value",
+		},
+		{
+			name: "partOf with empty reference",
+			organization: &fhir.Organization{
+				Id:     to.Ptr("org-1"),
+				PartOf: &fhir.Reference{Reference: to.Ptr("")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("parent-org"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: false,
+			description:   "should fail when partOf has empty reference string",
+		},
+		{
+			name: "partOf with nil reference string",
+			organization: &fhir.Organization{
+				Id:     to.Ptr("org-1"),
+				PartOf: &fhir.Reference{Reference: nil},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("parent-org"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: false,
+			description:   "should fail when partOf reference string is nil",
+		},
+		{
+			name: "organization with both URA and valid partOf",
+			organization: &fhir.Organization{
+				Id: to.Ptr("org-1"),
+				Identifier: []fhir.Identifier{
+					{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+				},
+				PartOf: &fhir.Reference{Reference: to.Ptr("Organization/parent-org")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("parent-org"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when organization has both valid URA and partOf (URA takes precedence)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOrganizationResource(tt.organization, tt.parentOrgMap)
+
+			if tt.shouldSucceed {
+				require.NoError(t, err, tt.description)
+			} else {
+				require.Error(t, err, tt.description)
+			}
+		})
+	}
+}
+
+func TestValidateLocationResource(t *testing.T) {
+	uraSystem := "http://fhir.nl/fhir/NamingSystem/ura"
+	ctx := t.Context()
+
+	tests := []struct {
+		name          string
+		location      *fhir.Location
+		parentOrgMap  map[*fhir.Organization][]*fhir.Organization
+		shouldSucceed bool
+		description   string
+	}{
+		// Single level org tree tests
+		{
+			name: "location with managingOrganization referencing parent org (single level)",
+			location: &fhir.Location{
+				Id:                   to.Ptr("location-1"),
+				ManagingOrganization: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when location references parent org in single-level tree",
+		},
+		{
+			name: "location with missing managingOrganization",
+			location: &fhir.Location{
+				Id: to.Ptr("location-1"),
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: false,
+			description:   "should fail when location has no managingOrganization",
+		},
+		{
+			name: "location referencing non-existent organization (single level)",
+			location: &fhir.Location{
+				Id:                   to.Ptr("location-1"),
+				ManagingOrganization: &fhir.Reference{Reference: to.Ptr("Organization/non-existent")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: false,
+			description:   "should fail when location references non-existent organization",
+		},
+		// One level org tree tests (parent + child)
+		{
+			name: "location referencing child org in one-level tree",
+			location: &fhir.Location{
+				Id:                   to.Ptr("location-1"),
+				ManagingOrganization: &fhir.Reference{Reference: to.Ptr("Organization/cardiology-dept")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("cardiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when location references child org in one-level tree",
+		},
+		{
+			name: "location referencing parent org with child orgs present",
+			location: &fhir.Location{
+				Id:                   to.Ptr("location-1"),
+				ManagingOrganization: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("cardiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("surgery-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when location references parent org in one-level tree",
+		},
+		// Multi-level org tree tests
+		{
+			name: "location referencing grandchild org in multi-level tree",
+			location: &fhir.Location{
+				Id:                   to.Ptr("location-1"),
+				ManagingOrganization: &fhir.Reference{Reference: to.Ptr("Organization/icu-cardiology")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("cardiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("icu-cardiology"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/cardiology-dept")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when location references grandchild org in multi-level tree",
+		},
+		{
+			name: "location in complex multi-level tree with multiple branches",
+			location: &fhir.Location{
+				Id:                   to.Ptr("location-1"),
+				ManagingOrganization: &fhir.Reference{Reference: to.Ptr("Organization/er-triage")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("cardiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("emergency-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("er-triage"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/emergency-dept")},
+					},
+					{
+						Id:     to.Ptr("er-trauma"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/emergency-dept")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when location references org in complex multi-branch tree",
+		},
+		// Multiple parent orgs tests
+		{
+			name: "location referencing org from one of multiple parent trees",
+			location: &fhir.Location{
+				Id:                   to.Ptr("location-1"),
+				ManagingOrganization: &fhir.Reference{Reference: to.Ptr("Organization/clinic-dept")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("11111")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("hospital-dept-a"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-a")},
+					},
+				},
+				{
+					Id: to.Ptr("clinic-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("22222")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("clinic-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/clinic-a")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when location references org from one of multiple parent trees",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLocationResource(ctx, tt.location, tt.parentOrgMap)
+
+			if tt.shouldSucceed {
+				require.NoError(t, err, tt.description)
+			} else {
+				require.Error(t, err, tt.description)
+			}
+		})
+	}
+}
+
+func TestValidatePractitionerRoleResource(t *testing.T) {
+	uraSystem := "http://fhir.nl/fhir/NamingSystem/ura"
+	ctx := t.Context()
+
+	tests := []struct {
+		name             string
+		practitionerRole *fhir.PractitionerRole
+		parentOrgMap     map[*fhir.Organization][]*fhir.Organization
+		shouldSucceed    bool
+		description      string
+	}{
+		// Single level org tree tests
+		{
+			name: "practitioner role with organization referencing parent org (single level)",
+			practitionerRole: &fhir.PractitionerRole{
+				Id:           to.Ptr("role-1"),
+				Organization: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when practitioner role references parent org in single-level tree",
+		},
+		{
+			name: "practitioner role with missing organization",
+			practitionerRole: &fhir.PractitionerRole{
+				Id: to.Ptr("role-1"),
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: false,
+			description:   "should fail when practitioner role has no organization reference",
+		},
+		{
+			name: "practitioner role referencing non-existent organization (single level)",
+			practitionerRole: &fhir.PractitionerRole{
+				Id:           to.Ptr("role-1"),
+				Organization: &fhir.Reference{Reference: to.Ptr("Organization/non-existent")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: false,
+			description:   "should fail when practitioner role references non-existent organization",
+		},
+		// One level org tree tests (parent + child)
+		{
+			name: "practitioner role referencing child org in one-level tree",
+			practitionerRole: &fhir.PractitionerRole{
+				Id:           to.Ptr("role-1"),
+				Organization: &fhir.Reference{Reference: to.Ptr("Organization/cardiology-dept")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("cardiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("surgery-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when practitioner role references child org in one-level tree",
+		},
+		{
+			name: "practitioner role referencing one of many children",
+			practitionerRole: &fhir.PractitionerRole{
+				Id:           to.Ptr("role-1"),
+				Organization: &fhir.Reference{Reference: to.Ptr("Organization/surgery-dept")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("cardiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("surgery-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("radiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when practitioner role references one of many child orgs",
+		},
+		// Multi-level org tree tests
+		{
+			name: "practitioner role referencing deep nested org (3 levels)",
+			practitionerRole: &fhir.PractitionerRole{
+				Id:           to.Ptr("role-1"),
+				Organization: &fhir.Reference{Reference: to.Ptr("Organization/icu-cardiology")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("cardiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("icu-cardiology"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/cardiology-dept")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when practitioner role references deep nested org",
+		},
+		{
+			name: "practitioner role in very deep tree (5 levels)",
+			practitionerRole: &fhir.PractitionerRole{
+				Id:           to.Ptr("role-1"),
+				Organization: &fhir.Reference{Reference: to.Ptr("Organization/unit-level-5")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("org-level-1"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("unit-level-2"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/org-level-1")},
+					},
+					{
+						Id:     to.Ptr("unit-level-3"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/unit-level-2")},
+					},
+					{
+						Id:     to.Ptr("unit-level-4"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/unit-level-3")},
+					},
+					{
+						Id:     to.Ptr("unit-level-5"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/unit-level-4")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when practitioner role references org in very deep tree (5 levels)",
+		},
+		// Multiple parent orgs tests
+		{
+			name: "practitioner role in multi-parent tree referencing second parent's child",
+			practitionerRole: &fhir.PractitionerRole{
+				Id:           to.Ptr("role-1"),
+				Organization: &fhir.Reference{Reference: to.Ptr("Organization/clinic-dept")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("11111")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("hospital-dept-a"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-a")},
+					},
+				},
+				{
+					Id: to.Ptr("clinic-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("22222")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("clinic-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/clinic-a")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when practitioner role references org from second parent tree",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePractitionerRoleResource(ctx, tt.practitionerRole, tt.parentOrgMap)
+
+			if tt.shouldSucceed {
+				require.NoError(t, err, tt.description)
+			} else {
+				require.Error(t, err, tt.description)
+			}
+		})
+	}
+}
+
+func TestValidateHealthcareServiceResource(t *testing.T) {
+	uraSystem := "http://fhir.nl/fhir/NamingSystem/ura"
+	ctx := t.Context()
+
+	tests := []struct {
+		name              string
+		healthcareService *fhir.HealthcareService
+		parentOrgMap      map[*fhir.Organization][]*fhir.Organization
+		shouldSucceed     bool
+		description       string
+	}{
+		// Single level org tree tests
+		{
+			name: "healthcare service with providedBy referencing parent org (single level)",
+			healthcareService: &fhir.HealthcareService{
+				Id:         to.Ptr("service-1"),
+				ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when healthcare service references parent org in single-level tree",
+		},
+		{
+			name: "healthcare service with missing providedBy",
+			healthcareService: &fhir.HealthcareService{
+				Id: to.Ptr("service-1"),
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: false,
+			description:   "should fail when healthcare service has no providedBy reference",
+		},
+		{
+			name: "healthcare service referencing non-existent organization (single level)",
+			healthcareService: &fhir.HealthcareService{
+				Id:         to.Ptr("service-1"),
+				ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/non-existent")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: false,
+			description:   "should fail when healthcare service references non-existent organization",
+		},
+		// One level org tree tests (parent + child)
+		{
+			name: "healthcare service referencing child org in one-level tree",
+			healthcareService: &fhir.HealthcareService{
+				Id:         to.Ptr("service-1"),
+				ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/cardiology-dept")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("cardiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("surgery-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when healthcare service references child org in one-level tree",
+		},
+		{
+			name: "healthcare service provided by parent with multiple departments",
+			healthcareService: &fhir.HealthcareService{
+				Id:         to.Ptr("service-1"),
+				ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("cardiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("surgery-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("radiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when healthcare service provided by parent with multiple departments",
+		},
+		// Multi-level org tree tests
+		{
+			name: "healthcare service referencing deep nested org (3 levels)",
+			healthcareService: &fhir.HealthcareService{
+				Id:         to.Ptr("service-1"),
+				ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/icu-cardiology")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("cardiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("icu-cardiology"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/cardiology-dept")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when healthcare service references deep nested org",
+		},
+		{
+			name: "healthcare service in complex multi-branch tree",
+			healthcareService: &fhir.HealthcareService{
+				Id:         to.Ptr("service-1"),
+				ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/er-trauma")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("cardiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("emergency-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("er-triage"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/emergency-dept")},
+					},
+					{
+						Id:     to.Ptr("er-trauma"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/emergency-dept")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when healthcare service references org in complex multi-branch tree",
+		},
+		// Multiple parent orgs tests
+		{
+			name: "healthcare service in multi-parent tree",
+			healthcareService: &fhir.HealthcareService{
+				Id:         to.Ptr("service-1"),
+				ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/clinic-dept")},
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("11111")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("hospital-dept-a"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-a")},
+					},
+				},
+				{
+					Id: to.Ptr("clinic-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("22222")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("clinic-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/clinic-a")},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when healthcare service references org from one of multiple parent trees",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateHealthcareServiceResource(ctx, tt.healthcareService, tt.parentOrgMap)
+
+			if tt.shouldSucceed {
+				require.NoError(t, err, tt.description)
+			} else {
+				require.Error(t, err, tt.description)
+			}
+		})
+	}
+}
+
+func TestValidateEndpointResource(t *testing.T) {
+	uraSystem := "http://fhir.nl/fhir/NamingSystem/ura"
+	ctx := t.Context()
+
+	tests := []struct {
+		name          string
+		endpoint      *fhir.Endpoint
+		parentOrgMap  map[*fhir.Organization][]*fhir.Organization
+		shouldSucceed bool
+		description   string
+	}{
+		// Single level org tree tests
+		{
+			name: "endpoint referenced by parent org (single level)",
+			endpoint: &fhir.Endpoint{
+				Id: to.Ptr("endpoint-1"),
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-1")},
+					},
+				}: {},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when endpoint is referenced by parent org in single-level tree",
+		},
+		{
+			name:     "endpoint with missing ID",
+			endpoint: &fhir.Endpoint{
+				// No ID
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {},
+			},
+			shouldSucceed: false,
+			description:   "should fail when endpoint has no ID",
+		},
+		{
+			name: "endpoint not referenced by any organization (single level)",
+			endpoint: &fhir.Endpoint{
+				Id: to.Ptr("endpoint-orphan"),
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-1")},
+					},
+				}: {},
+			},
+			shouldSucceed: false,
+			description:   "should fail when endpoint is not referenced by any organization",
+		},
+		// One level org tree tests (parent + child)
+		{
+			name: "endpoint referenced by child org in one-level tree",
+			endpoint: &fhir.Endpoint{
+				Id: to.Ptr("endpoint-1"),
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("cardiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+						Endpoint: []fhir.Reference{
+							{Reference: to.Ptr("Endpoint/endpoint-1")},
+						},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when endpoint is referenced by child org in one-level tree",
+		},
+		{
+			name: "endpoint referenced by multiple orgs in one-level tree",
+			endpoint: &fhir.Endpoint{
+				Id: to.Ptr("endpoint-shared"),
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-shared")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("cardiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+						Endpoint: []fhir.Reference{
+							{Reference: to.Ptr("Endpoint/endpoint-shared")},
+						},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when endpoint is referenced by multiple orgs",
+		},
+		{
+			name: "endpoint among multiple endpoints in org",
+			endpoint: &fhir.Endpoint{
+				Id: to.Ptr("endpoint-2"),
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-1")},
+						{Reference: to.Ptr("Endpoint/endpoint-2")},
+						{Reference: to.Ptr("Endpoint/endpoint-3")},
+					},
+				}: {},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when endpoint is one of multiple endpoints in org",
+		},
+		// Multi-level org tree tests
+		{
+			name: "endpoint referenced by deep nested org (3 levels)",
+			endpoint: &fhir.Endpoint{
+				Id: to.Ptr("endpoint-1"),
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("cardiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("icu-cardiology"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/cardiology-dept")},
+						Endpoint: []fhir.Reference{
+							{Reference: to.Ptr("Endpoint/endpoint-1")},
+						},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when endpoint is referenced by deep nested org",
+		},
+		{
+			name: "endpoint in complex multi-branch tree",
+			endpoint: &fhir.Endpoint{
+				Id: to.Ptr("endpoint-trauma"),
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("cardiology-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+						Endpoint: []fhir.Reference{
+							{Reference: to.Ptr("Endpoint/endpoint-cardio")},
+						},
+					},
+					{
+						Id:     to.Ptr("emergency-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					},
+					{
+						Id:     to.Ptr("er-trauma"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/emergency-dept")},
+						Endpoint: []fhir.Reference{
+							{Reference: to.Ptr("Endpoint/endpoint-trauma")},
+						},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when endpoint is referenced by org in complex multi-branch tree",
+		},
+		{
+			name: "endpoint with absolute URL reference",
+			endpoint: &fhir.Endpoint{
+				Id: to.Ptr("endpoint-1"),
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-main"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("12345")},
+					},
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("http://example.org/fhir/Endpoint/endpoint-1")},
+					},
+				}: {},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when endpoint is referenced with absolute URL",
+		},
+		// Multiple parent orgs tests
+		{
+			name: "endpoint in multi-parent tree referenced by second parent's child",
+			endpoint: &fhir.Endpoint{
+				Id: to.Ptr("endpoint-clinic"),
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("11111")},
+					},
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-hospital")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("hospital-dept-a"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/hospital-a")},
+					},
+				},
+				{
+					Id: to.Ptr("clinic-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("22222")},
+					},
+				}: {
+					{
+						Id:     to.Ptr("clinic-dept"),
+						PartOf: &fhir.Reference{Reference: to.Ptr("Organization/clinic-a")},
+						Endpoint: []fhir.Reference{
+							{Reference: to.Ptr("Endpoint/endpoint-clinic")},
+						},
+					},
+				},
+			},
+			shouldSucceed: true,
+			description:   "should succeed when endpoint is referenced by org from one of multiple parent trees",
+		},
+		{
+			name: "endpoint not referenced in multi-parent tree",
+			endpoint: &fhir.Endpoint{
+				Id: to.Ptr("endpoint-orphan"),
+			},
+			parentOrgMap: map[*fhir.Organization][]*fhir.Organization{
+				{
+					Id: to.Ptr("hospital-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("11111")},
+					},
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-hospital")},
+					},
+				}: {},
+				{
+					Id: to.Ptr("clinic-a"),
+					Identifier: []fhir.Identifier{
+						{System: to.Ptr(uraSystem), Value: to.Ptr("22222")},
+					},
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-clinic")},
+					},
+				}: {},
+			},
+			shouldSucceed: false,
+			description:   "should fail when endpoint is not referenced by any org in multi-parent tree",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateEndpointResource(ctx, tt.endpoint, tt.parentOrgMap)
+
+			if tt.shouldSucceed {
+				require.NoError(t, err, tt.description)
+			} else {
+				require.Error(t, err, tt.description)
 			}
 		})
 	}

--- a/test/e2e/mcsd/update_test.go
+++ b/test/e2e/mcsd/update_test.go
@@ -128,12 +128,12 @@ func Test_mCSDUpdateClient_IncrementalUpdates(t *testing.T) {
 			assert.Contains(t, org.Alias, "Updated Alias", "Organization alias should be updated")
 		})
 	})
-	t.Run("new organization in care provider Administration Directory", func(t *testing.T) {
+	t.Run("new child organization in care provider Administration Directory", func(t *testing.T) {
 		harnessDetail := harness.Start(t)
 		// Test verifies _since parameter correctly enables incremental sync by:
 		// 1. Doing baseline sync to establish timestamps
-		// 2. Creating new organization after sync completes
-		// 3. Verifying next sync finds the new organization via _since parameter
+		// 2. Creating new child organization after sync completes
+		// 3. Verifying next sync finds the new child organization via _since parameter
 		// 4. Confirming subsequent sync finds nothing (no new changes)
 
 		// First sync to establish baseline timestamps
@@ -144,42 +144,58 @@ func Test_mCSDUpdateClient_IncrementalUpdates(t *testing.T) {
 		require.NotNil(t, lrzaReport1, "LRZa report should exist in first sync")
 		assert.Equal(t, 2, lrzaReport1.CountCreated, "LRZa should create 2 resources in first sync")
 
-		// Create new organization after first sync - should be found by next incremental sync
+		// Create new child organization after first sync - should be found by next incremental sync
 		// Use discovered directory (care2cure-admin) since they sync all resource types including Organizations
 		care2CureFHIRClient := fhirclient.New(harnessDetail.Care2CureFHIRBaseURL, http.DefaultClient, &fhirclient.Config{
 			UsePostSearch: false,
 		})
-		orgName := "Test Organization for Incremental Sync"
+
+		// Find the parent organization with URA 00000030 in care2cure directory
+		parentURA := "00000030"
+		parentOrg, err := searchOrg(care2CureFHIRClient, parentURA)
+		require.NoError(t, err, "Failed to search for parent organization")
+		require.NotNil(t, parentOrg, "Parent organization with URA 00000030 should exist")
+		require.NotNil(t, parentOrg.Id, "Parent organization should have an ID")
+
+		// Create child organization that is partOf the parent organization
+		childOrgName := "Test Child Organization for Incremental Sync"
 		identifierUseOfficial := fhir.IdentifierUseOfficial
-		identifierSystem := "http://fhir.nl/fhir/NamingSystem/ura"
-		identifierValue := "99999999"
-		newOrg := fhir.Organization{
-			Name: &orgName,
+		identifierSystem := "http://fhir.nl/fhir/NamingSystem/a_non_ura"
+		childIdentifierValue := "incremental-test-999"
+		partOfReference := "Organization/" + *parentOrg.Id
+
+		childOrg := fhir.Organization{
+			Name: &childOrgName,
 			Identifier: []fhir.Identifier{
 				{
 					Use:    &identifierUseOfficial,
 					System: &identifierSystem,
-					Value:  &identifierValue,
+					Value:  &childIdentifierValue,
 				},
+			},
+			PartOf: &fhir.Reference{
+				Reference: &partOfReference,
 			},
 		}
 
-		var createdOrg fhir.Organization
-		err := care2CureFHIRClient.CreateWithContext(t.Context(), newOrg, &createdOrg)
-		require.NoError(t, err, "Failed to create new organization for incremental test")
+		var createdChildOrg fhir.Organization
+		err = care2CureFHIRClient.CreateWithContext(t.Context(), childOrg, &createdChildOrg)
+		require.NoError(t, err, "Failed to create new child organization for incremental test")
 
-		// Verify the organization was actually created by reading it back
-		var readBackOrg fhir.Organization
-		err = care2CureFHIRClient.ReadWithContext(t.Context(), "Organization/"+*createdOrg.Id, &readBackOrg)
-		require.NoError(t, err, "Failed to read back created organization")
-		require.Equal(t, orgName, *readBackOrg.Name, "Organization name should match")
-		// Second sync - should use _since and only find new resources (our test organization)
+		// Verify the child organization was actually created by reading it back
+		var readBackChildOrg fhir.Organization
+		err = care2CureFHIRClient.ReadWithContext(t.Context(), "Organization/"+*createdChildOrg.Id, &readBackChildOrg)
+		require.NoError(t, err, "Failed to read back created child organization")
+		require.Equal(t, childOrgName, *readBackChildOrg.Name, "Child organization name should match")
+		require.NotNil(t, readBackChildOrg.PartOf, "Child organization should have partOf reference")
+
+		// Second sync - should use _since and only find new resources (our test child organization)
 		response2 := invokeUpdate(t, harnessDetail.KnooppuntInternalBaseURL)
 
-		// Second sync should find our test organization via _since parameter
+		// Second sync should find our test child organization via _since parameter
 		care2CureReport2 := mapEntrySuffix(response2, "care2cure-admin")
 		require.NotNil(t, care2CureReport2, "Care2Cure report should exist in second sync")
-		assert.Equal(t, 1, care2CureReport2.CountCreated, "Care2Cure should find exactly 1 resource (our test organization) via _since parameter")
+		assert.Equal(t, 1, care2CureReport2.CountCreated, "Care2Cure should find exactly 1 resource (our test child organization) via _since parameter")
 
 		// Third sync - should find nothing (no new resources since second sync)
 		response3 := invokeUpdate(t, harnessDetail.KnooppuntInternalBaseURL)
@@ -240,7 +256,7 @@ func Test_DuplicateResourceHandling(t *testing.T) {
 
 	harnessDetail := harness.Start(t)
 
-	t.Run("POST+PUT+PUT scenario with same resource", func(t *testing.T) {
+	t.Run("POST+PUT+PUT scenario with child organization", func(t *testing.T) {
 		// First, do an initial sync to handle any existing testdata
 		_ = invokeUpdate(t, harnessDetail.KnooppuntInternalBaseURL)
 
@@ -249,52 +265,62 @@ func Test_DuplicateResourceHandling(t *testing.T) {
 			UsePostSearch: false,
 		})
 
-		// 1. Create standalone organization (POST) - no references to avoid UUID resolution issues
-		orgName := "Test Duplicate Organization"
-		identifierUseOfficial := fhir.IdentifierUseOfficial
-		identifierSystem := "http://fhir.nl/fhir/NamingSystem/ura"
-		identifierValue := "duplicate-test-123"
-		active := true
+		// Find the parent organization with URA 00000030 in care2cure directory
+		parentURA := "00000030"
+		parentOrg, err := searchOrg(care2CureFHIRClient, parentURA)
+		require.NoError(t, err, "Failed to search for parent organization")
+		require.NotNil(t, parentOrg, "Parent organization with URA 00000030 should exist")
+		require.NotNil(t, parentOrg.Id, "Parent organization should have an ID")
 
-		newOrg := fhir.Organization{
-			Name:   &orgName,
+		// 1. Create child organization (POST) that is partOf the parent organization
+		childOrgName := "Test Child Organization"
+		identifierUseOfficial := fhir.IdentifierUseOfficial
+		identifierSystem := "http://fhir.nl/fhir/NamingSystem/a_non_ura"
+		childIdentifierValue := "child-test-456"
+		active := true
+		partOfReference := "Organization/" + *parentOrg.Id
+
+		childOrg := fhir.Organization{
+			Name:   &childOrgName,
 			Active: &active,
 			Identifier: []fhir.Identifier{
 				{
 					Use:    &identifierUseOfficial,
 					System: &identifierSystem,
-					Value:  &identifierValue,
+					Value:  &childIdentifierValue,
 				},
 			},
-			// Don't add endpoint references to avoid UUID resolution issues
+			PartOf: &fhir.Reference{
+				Reference: &partOfReference,
+			},
 		}
 
-		var createdOrg fhir.Organization
-		err := care2CureFHIRClient.CreateWithContext(t.Context(), newOrg, &createdOrg)
-		require.NoError(t, err, "Failed to create organization")
+		var createdChildOrg fhir.Organization
+		err = care2CureFHIRClient.CreateWithContext(t.Context(), childOrg, &createdChildOrg)
+		require.NoError(t, err, "Failed to create child organization")
 
-		// 2. Update organization (first PUT)
-		updatedName1 := "Test Duplicate Organization - Updated 1"
-		createdOrg.Name = &updatedName1
+		// 2. Update child organization (first PUT)
+		updatedName1 := "Test Child Organization - Updated 1"
+		createdChildOrg.Name = &updatedName1
 
-		var updatedOrg1 fhir.Organization
-		err = care2CureFHIRClient.UpdateWithContext(t.Context(), "Organization/"+*createdOrg.Id, createdOrg, &updatedOrg1)
-		require.NoError(t, err, "Failed to update organization (first time)")
+		var updatedChildOrg1 fhir.Organization
+		err = care2CureFHIRClient.UpdateWithContext(t.Context(), "Organization/"+*createdChildOrg.Id, createdChildOrg, &updatedChildOrg1)
+		require.NoError(t, err, "Failed to update child organization (first time)")
 
-		// 3. Update organization again (second PUT)
-		updatedName2 := "Test Duplicate Organization - Updated 2"
-		updatedOrg1.Name = &updatedName2
+		// 3. Update child organization again (second PUT)
+		updatedName2 := "Test Child Organization - Updated 2"
+		updatedChildOrg1.Name = &updatedName2
 
-		var updatedOrg2 fhir.Organization
-		err = care2CureFHIRClient.UpdateWithContext(t.Context(), "Organization/"+*updatedOrg1.Id, updatedOrg1, &updatedOrg2)
-		require.NoError(t, err, "Failed to update organization (second time)")
+		var updatedChildOrg2 fhir.Organization
+		err = care2CureFHIRClient.UpdateWithContext(t.Context(), "Organization/"+*updatedChildOrg1.Id, updatedChildOrg1, &updatedChildOrg2)
+		require.NoError(t, err, "Failed to update child organization (second time)")
 
-		// Verify the source organization now has version 3 after POST(v1) + PUT(v2) + PUT(v3)
-		require.NotNil(t, updatedOrg2.Meta, "Updated organization should have meta")
-		require.NotNil(t, updatedOrg2.Meta.VersionId, "Updated organization should have version ID")
-		assert.Equal(t, "3", *updatedOrg2.Meta.VersionId, "Source server should assign version 3 after POST+PUT+PUT sequence")
+		// Verify the source child organization now has version 3 after POST(v1) + PUT(v2) + PUT(v3)
+		require.NotNil(t, updatedChildOrg2.Meta, "Updated child organization should have meta")
+		require.NotNil(t, updatedChildOrg2.Meta.VersionId, "Updated child organization should have version ID")
+		assert.Equal(t, "3", *updatedChildOrg2.Meta.VersionId, "Source server should assign version 3 after POST+PUT+PUT sequence")
 
-		// 4. Now run mCSD sync to see how it handles the POST+PUT+PUT history
+		// 4. Now run mCSD sync to see how it handles the POST+PUT+PUT history for child organization
 		updateReport := invokeUpdate(t, harnessDetail.KnooppuntInternalBaseURL)
 
 		// Check that no errors occurred during sync
@@ -302,76 +328,100 @@ func Test_DuplicateResourceHandling(t *testing.T) {
 		require.NotNil(t, care2CureReport, "Care2Cure report should exist")
 		require.Empty(t, care2CureReport.Errors, "Should not have errors with conditional _source updates")
 
-		// 5. Verify only ONE organization exists in query directory with the latest name
+		// 5. Verify only ONE child organization exists in query directory with the latest name
 		queryFHIRClient := fhirclient.New(harnessDetail.MCSDQueryFHIRBaseURL, http.DefaultClient, nil)
 
-		// Search for organizations with our test identifier
+		// Search for child organizations with our test identifier
 		searchResults := fhir.Bundle{}
 		err = queryFHIRClient.SearchWithContext(t.Context(), "Organization", url.Values{
-			"identifier": []string{identifierSystem + "|" + identifierValue},
+			"identifier": []string{identifierSystem + "|" + childIdentifierValue},
 		}, &searchResults)
-		require.NoError(t, err, "Failed to search for organizations in query directory")
+		require.NoError(t, err, "Failed to search for child organizations in query directory")
 
-		// Should find exactly ONE organization (not duplicates) after deduplication
-		require.Len(t, searchResults.Entry, 1, "Should have exactly 1 organization in query directory after POST+PUT+PUT deduplication")
+		// Should find exactly ONE child organization (not duplicates) after deduplication
+		require.Len(t, searchResults.Entry, 1, "Should have exactly 1 child organization in query directory after POST+PUT+PUT deduplication")
 
 		// Verify it has the latest name (from the second update)
-		var foundOrg fhir.Organization
-		require.NoError(t, json.Unmarshal(searchResults.Entry[0].Resource, &foundOrg))
-		assert.Equal(t, "Test Duplicate Organization - Updated 2", *foundOrg.Name, "Should have the latest version of the organization")
+		var foundChildOrg fhir.Organization
+		require.NoError(t, json.Unmarshal(searchResults.Entry[0].Resource, &foundChildOrg))
+		assert.Equal(t, "Test Child Organization - Updated 2", *foundChildOrg.Name, "Should have the latest version of the child organization")
+
+		// Verify the partOf reference is preserved
+		require.NotNil(t, foundChildOrg.PartOf, "Child organization should have partOf reference")
+		require.NotNil(t, foundChildOrg.PartOf.Reference, "Child organization partOf should have reference")
+		assert.Contains(t, *foundChildOrg.PartOf.Reference, "Organization/", "Child organization partOf should reference parent organization")
 
 		// Verify it has the expected version ID
 		// Source server: POST(v1) + PUT(v2) + PUT(v3) = version 3
 		// Query server: receives deduped resource and creates it as version 1
-		require.NotNil(t, foundOrg.Meta, "Organization should have meta")
-		require.NotNil(t, foundOrg.Meta.VersionId, "Organization should have version ID")
-		assert.Equal(t, "1", *foundOrg.Meta.VersionId, "Query server should assign version 1 to the synchronized resource")
+		require.NotNil(t, foundChildOrg.Meta, "Child organization should have meta")
+		require.NotNil(t, foundChildOrg.Meta.VersionId, "Child organization should have version ID")
+		assert.Equal(t, "1", *foundChildOrg.Meta.VersionId, "Query server should assign version 1 to the synchronized resource")
 	})
 
-	t.Run("CREATE+DELETE scenario", func(t *testing.T) {
+	t.Run("CREATE+DELETE scenario with child organization", func(t *testing.T) {
+		// First, do an initial sync to handle any existing testdata
+		_ = invokeUpdate(t, harnessDetail.KnooppuntInternalBaseURL)
+
 		// Use care2cure FHIR server as the source (discovered directory)
 		care2CureFHIRClient := fhirclient.New(harnessDetail.Care2CureFHIRBaseURL, http.DefaultClient, &fhirclient.Config{
 			UsePostSearch: false,
 		})
 
-		// 1. Create organization (POST)
-		orgName := "Test Organization for Deletion"
-		identifierUseOfficial := fhir.IdentifierUseOfficial
-		identifierSystem := "http://fhir.nl/fhir/NamingSystem/ura"
-		identifierValue := "delete-test-456"
-		active := true
+		// Find the parent organization with URA 00000030 in care2cure directory
+		parentURA := "00000030"
+		parentOrg, err := searchOrg(care2CureFHIRClient, parentURA)
+		require.NoError(t, err, "Failed to search for parent organization")
+		require.NotNil(t, parentOrg, "Parent organization with URA 00000030 should exist")
+		require.NotNil(t, parentOrg.Id, "Parent organization should have an ID")
 
-		newOrg := fhir.Organization{
-			Name:   &orgName,
+		// 1. Create child organization (POST) that is partOf the parent organization
+		childOrgName := "Test Child Organization for Deletion"
+		identifierUseOfficial := fhir.IdentifierUseOfficial
+		identifierSystem := "http://fhir.nl/fhir/NamingSystem/a_non_ura"
+		childIdentifierValue := "delete-test-789"
+		active := true
+		partOfReference := "Organization/" + *parentOrg.Id
+
+		childOrg := fhir.Organization{
+			Name:   &childOrgName,
 			Active: &active,
 			Identifier: []fhir.Identifier{
 				{
 					Use:    &identifierUseOfficial,
 					System: &identifierSystem,
-					Value:  &identifierValue,
+					Value:  &childIdentifierValue,
 				},
+			},
+			PartOf: &fhir.Reference{
+				Reference: &partOfReference,
 			},
 		}
 
-		var createdOrg fhir.Organization
-		err := care2CureFHIRClient.CreateWithContext(t.Context(), newOrg, &createdOrg)
-		require.NoError(t, err, "Failed to create organization for deletion test")
+		var createdChildOrg fhir.Organization
+		err = care2CureFHIRClient.CreateWithContext(t.Context(), childOrg, &createdChildOrg)
+		require.NoError(t, err, "Failed to create child organization for deletion test")
 
-		// 2. First sync - should create the organization in query directory
+		// 2. First sync - should create the child organization in query directory
 		_ = invokeUpdate(t, harnessDetail.KnooppuntInternalBaseURL)
 
-		// Verify organization exists in query directory
+		// Verify child organization exists in query directory
 		queryFHIRClient := fhirclient.New(harnessDetail.MCSDQueryFHIRBaseURL, http.DefaultClient, nil)
 		searchResults1 := fhir.Bundle{}
 		err = queryFHIRClient.SearchWithContext(t.Context(), "Organization", url.Values{
-			"identifier": []string{identifierSystem + "|" + identifierValue},
+			"identifier": []string{identifierSystem + "|" + childIdentifierValue},
 		}, &searchResults1)
-		require.NoError(t, err, "Failed to search for organizations in query directory")
-		require.Len(t, searchResults1.Entry, 1, "Should have 1 organization in query directory before deletion")
+		require.NoError(t, err, "Failed to search for child organizations in query directory")
+		require.Len(t, searchResults1.Entry, 1, "Should have 1 child organization in query directory before deletion")
 
-		// 3. Delete the organization from source
-		err = care2CureFHIRClient.DeleteWithContext(t.Context(), "Organization/"+*createdOrg.Id)
-		require.NoError(t, err, "Failed to delete organization from source")
+		// Verify the partOf reference exists
+		var foundChildOrg1 fhir.Organization
+		require.NoError(t, json.Unmarshal(searchResults1.Entry[0].Resource, &foundChildOrg1))
+		require.NotNil(t, foundChildOrg1.PartOf, "Child organization should have partOf reference before deletion")
+
+		// 3. Delete the child organization from source
+		err = care2CureFHIRClient.DeleteWithContext(t.Context(), "Organization/"+*createdChildOrg.Id)
+		require.NoError(t, err, "Failed to delete child organization from source")
 
 		// 4. Second sync - should process the deletion
 		updateReport := invokeUpdate(t, harnessDetail.KnooppuntInternalBaseURL)
@@ -379,16 +429,16 @@ func Test_DuplicateResourceHandling(t *testing.T) {
 		care2CureReport2 := mapEntrySuffix(updateReport, "care2cure-admin")
 		require.NotNil(t, care2CureReport2, "Care2Cure report should exist after deletion")
 
-		// 5. Verify organization is deleted from query directory
+		// 5. Verify child organization is deleted from query directory
 		searchResults2 := fhir.Bundle{}
 		err = queryFHIRClient.SearchWithContext(t.Context(), "Organization", url.Values{
-			"identifier": []string{identifierSystem + "|" + identifierValue},
+			"identifier": []string{identifierSystem + "|" + childIdentifierValue},
 		}, &searchResults2)
-		require.NoError(t, err, "Failed to search for organizations in query directory after deletion")
+		require.NoError(t, err, "Failed to search for child organizations in query directory after deletion")
 
 		// DELETE operations are now properly processed using conditional _source deletions
-		// The organization should be removed from the query directory
-		require.Len(t, searchResults2.Entry, 0, "Should have 0 organizations in query directory after DELETE is processed")
+		// The child organization should be removed from the query directory
+		require.Len(t, searchResults2.Entry, 0, "Should have 0 child organizations in query directory after DELETE is processed")
 
 		// Verify the DeleteCount is 1 in the sync report (confirming DELETE was processed)
 		require.Equal(t, 1, care2CureReport2.CountDeleted, "DELETE operations should be processed and counted")


### PR DESCRIPTION
This PR addresses 2 main issues:
- #290 (before some organizations passed through the cracks in some cases)
- adds extensive testing for the authoritative checks

Furthermore:
- potentially fixes #289  as well, because in some cases, with multi-layered org tree map (3+), Resources weren't validated properly