### PR TITLE
 fix(mcsd): increase FHIR search page size to work around pagination issue

### DIFF
--- a/component/mcsd/component.go
+++ b/component/mcsd/component.go
@@ -40,7 +40,7 @@ const maxUpdateEntries = 1000
 
 // searchPageSize is an arbitrary FHIR search result limit (per page), so we have deterministic behavior across FHIR servers,
 // and don't rely on server defaults (which may be very high or very low (Azure FHIR's default is 10)).
-const searchPageSize = 100
+const searchPageSize = 10000
 
 // Component implements a mCSD Update Client, which synchronizes mCSD FHIR resources from remote mCSD Directories to a local mCSD Directory for querying.
 // It is configured with a root mCSD Directory, which is used to discover organizations and their mCSD Directory endpoints.


### PR DESCRIPTION
 ## Summary
  - Increases `searchPageSize` from 100 to 10000 in the mCSD update client as a workaround for a pagination issue

 ## Background
  The mCSD update client fetches FHIR resources from remote directories. The previous page size of 100 was causing issues with pagination handling. This change increases the limit to 10000 to effectively fetch all results in a single page, bypassing the pagination problem.

