### PR TITLE
Vektis Issuer: fix CORS issue with redirect

### DIFF
--- a/mock-components/vc-issuer/app/api/oidc4vci/authorize/callback/route.ts
+++ b/mock-components/vc-issuer/app/api/oidc4vci/authorize/callback/route.ts
@@ -79,7 +79,7 @@ export async function GET(req: NextRequest) {
     },
   });
 
-  // Build form POST to redirect with authorization code
+  // Build form GET to redirect with authorization code
   const redirectUri = authRequest.redirectUri;
   const code = authRequest.generatedCode;
   const authState = authRequest.state;
@@ -125,7 +125,7 @@ export async function GET(req: NextRequest) {
       <body>
         <div class="container">
           <p>Redirecting...</p>
-          <form id="redirectForm" method="POST" action="${redirectUri}">
+          <form id="redirectForm" method="GET" action="${redirectUri}">
             <input type="hidden" name="code" value="${code}" />
             ${authState ? `<input type="hidden" name="state" value="${authState}" />` : ''}
             <button type="submit">Click here if you are not automatically redirected</button>


### PR DESCRIPTION
After issuance, the browser is redirected back with a `Location` header, but this breaks as it redirects to the Nuts node on a different domain, which doesn't provide proper CORS headers.

Easiest fix for now is to use a navigation step instead of a `Location` header to redirect.