### PR TITLE
PDP: Allow patient ID in BgZ policy, and make it required

### DIFF
--- a/component/pdp/policies/bgz/policy.rego
+++ b/component/pdp/policies/bgz/policy.rego
@@ -11,10 +11,21 @@ default allow := false
 allow if {
     input.context.mitz_consent == true
     # The BgZ on Generic Functions use case (to be formalized) specifies that requests must be scoped to a patient.
-    # We enforce this by checking that a patient_id is present in the request context.
+    # We enforce this by checking that either a patient_id or patient_bsn is present in the request context.
+    has_patient_identifier
+    is_allowed_query
+}
+
+# Helper rule: check if either patient_id or patient_bsn is filled
+has_patient_identifier if {
     is_string(input.context.patient_id)
     input.context.patient_id != ""
-    is_allowed_query
+}
+
+has_patient_identifier if {
+    # Remove this after february 2026 hackaton.
+    is_string(input.context.patient_bsn)
+    input.context.patient_bsn != ""
 }
 
 # GET [base]/Patient?_include=Patient:general-practitioner


### PR DESCRIPTION
A patient ID is required, because queries need to be search narrowed. There must be a patient, because the Mitz check must also succeed, but this makes it explicit that the FHIR queries must contain a patient-ID.

Note: per request of @gasperr I also added patient_bsn, which can be removed after the upcoming hackaton(?).