### PR TITLE
Update PZP policy

### DIFF
--- a/component/pdp/component_test.go
+++ b/component/pdp/component_test.go
@@ -215,9 +215,15 @@ func TestHandleMainPolicy_Integration(t *testing.T) {
 				decision:             false,
 			},
 			{
-				name:                 "allow - Consent search with patient and _profile",
+				name:                 "allow - Consent search with patient, scope and category",
 				clientQualifications: []string{"pzp_gf"},
-				httpRequest:          `GET /Consent?patient=Patient/1000&_profile=http://nictiz.nl/fhir/StructureDefinition/nl-core-TreatmentDirective2`,
+				httpRequest:          `GET /Consent?patient=Patient/1000&scope=http://terminology.hl7.org/CodeSystem/consentscope|treatment&category=http://snomed.info/sct|129125009`,
+				decision:             true,
+			},
+			{
+				name:                 "allow - Consent search with patient, scope, category and include",
+				clientQualifications: []string{"pzp_gf"},
+				httpRequest:          `GET /Consent?patient=Patient/1000&scope=http://terminology.hl7.org/CodeSystem/consentscope|treatment&category=http://snomed.info/sct|129125009&_include=Consent:actor`,
 				decision:             true,
 			},
 			{

--- a/component/pdp/policies/pzp_gf/fhir_capabilitystatement.json
+++ b/component/pdp/policies/pzp_gf/fhir_capabilitystatement.json
@@ -45,9 +45,16 @@
               "type": "reference"
             },
             {
-              "name": "_profile",
-              "type": "uri"
+              "name": "scope",
+              "type": "string"
+            },
+            {
+              "name": "category",
+              "type": "string"
             }
+          ],
+          "searchInclude": [
+            "Consent:actor"
           ]
         }
       ]

--- a/component/pdp/policies/pzp_gf/policy.rego
+++ b/component/pdp/policies/pzp_gf/policy.rego
@@ -23,13 +23,12 @@ is_allowed_query if {
     startswith(input.action.fhir_rest.search_params.identifier, "http://fhir.nl/fhir/NamingSystem/bsn|")
 }
 
-# GET [base]/Consent?patient={reference}&_profile=http://nictiz.nl/fhir/StructureDefinition/nl-core-TreatmentDirective2
+# GET [base]/Consent?patient={reference}&scope=http://terminology.hl7.org/CodeSystem/consentscope|treatment&category=http://snomed.info/sct|129125009
 is_allowed_query if {
     input.resource.type == "Consent"
     input.action.fhir_rest.interaction_type == "search-type"
     # patient: reference Patient resource
     startswith(input.action.fhir_rest.search_params.patient, "Patient/")
-    # _profile
-    is_string(input.action.fhir_rest.search_params._profile)
-    input.action.fhir_rest.search_params._profile == "http://nictiz.nl/fhir/StructureDefinition/nl-core-TreatmentDirective2"
+    input.action.fhir_rest.search_params.scope == "http://terminology.hl7.org/CodeSystem/consentscope|treatment"
+    input.action.fhir_rest.search_params.category == "http://snomed.info/sct|129125009"
 }


### PR DESCRIPTION
Small PR with an update to the PZP policy for the Consent call adding this format:

`Query: GET [base]/Consent?patient=[id]&scope=http://terminology.hl7.org/CodeSystem/consentscope%7Ctreatment&category=http://snomed.info/sct%7C129125009&_include=Consent:actor`

See: https://github.com/nuts-foundation/nl-generic-functions-ig/discussions/70