### PR TITLE
Unmarshal HealthcareServices used for validation once

### DIFF
--- a/component/mcsd/component.go
+++ b/component/mcsd/component.go
@@ -358,7 +358,7 @@ func (c *Component) updateFromDirectory(ctx context.Context, fhirBaseURLRaw stri
 	deduplicatedEntries := deduplicateHistoryEntries(entries)
 
 	// Filter to only include HealthcareService resources
-	var allHealthcareServices []fhir.BundleEntry
+	var allHealthcareServices []fhir.HealthcareService
 	for _, entry := range entries {
 		if entry.Resource == nil {
 			continue
@@ -366,7 +366,7 @@ func (c *Component) updateFromDirectory(ctx context.Context, fhirBaseURLRaw stri
 		var healthcareService fhir.HealthcareService
 		if err := json.Unmarshal(entry.Resource, &healthcareService); err == nil {
 			// Successfully unmarshaled as HealthcareService
-			allHealthcareServices = append(allHealthcareServices, entry)
+			allHealthcareServices = append(allHealthcareServices, healthcareService)
 		}
 	}
 

--- a/component/mcsd/updater.go
+++ b/component/mcsd/updater.go
@@ -25,7 +25,7 @@ import (
 //
 // Resources are only synced to the query directory if they come from non-discoverable directories.
 // Discoverable directories are for discovery only and their resources should not be synced.
-func buildUpdateTransaction(ctx context.Context, tx *fhir.Bundle, entry fhir.BundleEntry, validationRules ValidationRules, parentOrganizationMap map[*fhir.Organization][]*fhir.Organization, allHealthcareServices []fhir.BundleEntry, isDiscoverableDirectory bool, sourceBaseURL string) (string, error) {
+func buildUpdateTransaction(ctx context.Context, tx *fhir.Bundle, entry fhir.BundleEntry, validationRules ValidationRules, parentOrganizationMap map[*fhir.Organization][]*fhir.Organization, allHealthcareServices []fhir.HealthcareService, isDiscoverableDirectory bool, sourceBaseURL string) (string, error) {
 	if entry.FullUrl == nil {
 		return "", errors.New("missing 'fullUrl' field")
 	}

--- a/component/mcsd/validator_test.go
+++ b/component/mcsd/validator_test.go
@@ -1702,7 +1702,7 @@ func TestValidateEndpointResourceReferencedByHealthcareService(t *testing.T) {
 		name                  string
 		endpoint              *fhir.Endpoint
 		parentOrgMap          map[*fhir.Organization][]*fhir.Organization
-		allHealthcareServices []fhir.BundleEntry
+		allHealthcareServices []fhir.HealthcareService
 		shouldSucceed         bool
 		description           string
 	}{
@@ -1719,15 +1719,13 @@ func TestValidateEndpointResourceReferencedByHealthcareService(t *testing.T) {
 					},
 				}: {},
 			},
-			allHealthcareServices: []fhir.BundleEntry{
+			allHealthcareServices: []fhir.HealthcareService{
 				{
-					Resource: mustMarshalJSON(&fhir.HealthcareService{
-						Id:         to.Ptr("hcs-1"),
-						ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
-						Endpoint: []fhir.Reference{
-							{Reference: to.Ptr("Endpoint/endpoint-hcs-1")},
-						},
-					}),
+					Id:         to.Ptr("hcs-1"),
+					ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-hcs-1")},
+					},
 				},
 			},
 			shouldSucceed: true,
@@ -1746,15 +1744,13 @@ func TestValidateEndpointResourceReferencedByHealthcareService(t *testing.T) {
 					},
 				}: {},
 			},
-			allHealthcareServices: []fhir.BundleEntry{
+			allHealthcareServices: []fhir.HealthcareService{
 				{
-					Resource: mustMarshalJSON(&fhir.HealthcareService{
-						Id:         to.Ptr("hcs-2"),
-						ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
-						Endpoint: []fhir.Reference{
-							{Reference: to.Ptr("http://example.org/fhir/Endpoint/endpoint-hcs-2")},
-						},
-					}),
+					Id:         to.Ptr("hcs-2"),
+					ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("http://example.org/fhir/Endpoint/endpoint-hcs-2")},
+					},
 				},
 			},
 			shouldSucceed: true,
@@ -1773,17 +1769,15 @@ func TestValidateEndpointResourceReferencedByHealthcareService(t *testing.T) {
 					},
 				}: {},
 			},
-			allHealthcareServices: []fhir.BundleEntry{
+			allHealthcareServices: []fhir.HealthcareService{
 				{
-					Resource: mustMarshalJSON(&fhir.HealthcareService{
-						Id:         to.Ptr("hcs-multi"),
-						ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
-						Endpoint: []fhir.Reference{
-							{Reference: to.Ptr("Endpoint/endpoint-hcs-1")},
-							{Reference: to.Ptr("Endpoint/endpoint-hcs-2")},
-							{Reference: to.Ptr("Endpoint/endpoint-hcs-3")},
-						},
-					}),
+					Id:         to.Ptr("hcs-multi"),
+					ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-hcs-1")},
+						{Reference: to.Ptr("Endpoint/endpoint-hcs-2")},
+						{Reference: to.Ptr("Endpoint/endpoint-hcs-3")},
+					},
 				},
 			},
 			shouldSucceed: true,
@@ -1802,24 +1796,20 @@ func TestValidateEndpointResourceReferencedByHealthcareService(t *testing.T) {
 					},
 				}: {},
 			},
-			allHealthcareServices: []fhir.BundleEntry{
+			allHealthcareServices: []fhir.HealthcareService{
 				{
-					Resource: mustMarshalJSON(&fhir.HealthcareService{
-						Id:         to.Ptr("hcs-cardiology"),
-						ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
-						Endpoint: []fhir.Reference{
-							{Reference: to.Ptr("Endpoint/endpoint-cardio")},
-						},
-					}),
+					Id:         to.Ptr("hcs-cardiology"),
+					ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-cardio")},
+					},
 				},
 				{
-					Resource: mustMarshalJSON(&fhir.HealthcareService{
-						Id:         to.Ptr("hcs-emergency"),
-						ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
-						Endpoint: []fhir.Reference{
-							{Reference: to.Ptr("Endpoint/endpoint-hcs-4")},
-						},
-					}),
+					Id:         to.Ptr("hcs-emergency"),
+					ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-hcs-4")},
+					},
 				},
 			},
 			shouldSucceed: true,
@@ -1841,14 +1831,12 @@ func TestValidateEndpointResourceReferencedByHealthcareService(t *testing.T) {
 					},
 				}: {},
 			},
-			allHealthcareServices: []fhir.BundleEntry{
+			allHealthcareServices: []fhir.HealthcareService{
 				{
-					Resource: mustMarshalJSON(&fhir.HealthcareService{
-						Id: to.Ptr("hcs-1"),
-						Endpoint: []fhir.Reference{
-							{Reference: to.Ptr("Endpoint/endpoint-different")},
-						},
-					}),
+					Id: to.Ptr("hcs-1"),
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-different")},
+					},
 				},
 			},
 			shouldSucceed: false,
@@ -1870,14 +1858,12 @@ func TestValidateEndpointResourceReferencedByHealthcareService(t *testing.T) {
 					},
 				}: {},
 			},
-			allHealthcareServices: []fhir.BundleEntry{
+			allHealthcareServices: []fhir.HealthcareService{
 				{
-					Resource: mustMarshalJSON(&fhir.HealthcareService{
-						Id: to.Ptr("hcs-1"),
-						Endpoint: []fhir.Reference{
-							{Reference: to.Ptr("Endpoint/endpoint-shared")},
-						},
-					}),
+					Id: to.Ptr("hcs-1"),
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-shared")},
+					},
 				},
 			},
 			shouldSucceed: true,
@@ -1897,15 +1883,13 @@ func TestValidateEndpointResourceReferencedByHealthcareService(t *testing.T) {
 					// No endpoint references in organization
 				}: {},
 			},
-			allHealthcareServices: []fhir.BundleEntry{
+			allHealthcareServices: []fhir.HealthcareService{
 				{
-					Resource: mustMarshalJSON(&fhir.HealthcareService{
-						Id:         to.Ptr("hcs-1"),
-						ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
-						Endpoint: []fhir.Reference{
-							{Reference: to.Ptr("Endpoint/endpoint-hcs-only")},
-						},
-					}),
+					Id:         to.Ptr("hcs-1"),
+					ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-hcs-only")},
+					},
 				},
 			},
 			shouldSucceed: true,
@@ -1924,7 +1908,7 @@ func TestValidateEndpointResourceReferencedByHealthcareService(t *testing.T) {
 					},
 				}: {},
 			},
-			allHealthcareServices: []fhir.BundleEntry{},
+			allHealthcareServices: []fhir.HealthcareService{},
 			shouldSucceed:         false,
 			description:           "should fail when healthcare services list is empty and endpoint not in org",
 		},
@@ -1941,12 +1925,10 @@ func TestValidateEndpointResourceReferencedByHealthcareService(t *testing.T) {
 					},
 				}: {},
 			},
-			allHealthcareServices: []fhir.BundleEntry{
+			allHealthcareServices: []fhir.HealthcareService{
 				{
-					Resource: mustMarshalJSON(&fhir.HealthcareService{
-						Id:       to.Ptr("hcs-1"),
-						Endpoint: nil, // No endpoints
-					}),
+					Id:       to.Ptr("hcs-1"),
+					Endpoint: nil, // No endpoints
 				},
 			},
 			shouldSucceed: false,
@@ -1965,15 +1947,13 @@ func TestValidateEndpointResourceReferencedByHealthcareService(t *testing.T) {
 					},
 				}: {},
 			},
-			allHealthcareServices: []fhir.BundleEntry{
+			allHealthcareServices: []fhir.HealthcareService{
 				{
-					Resource: mustMarshalJSON(&fhir.HealthcareService{
-						Id: to.Ptr("hcs-invalid"),
-						// Missing ProvidedBy - healthcare service is invalid
-						Endpoint: []fhir.Reference{
-							{Reference: to.Ptr("Endpoint/endpoint-invalid")},
-						},
-					}),
+					Id: to.Ptr("hcs-invalid"),
+					// Missing ProvidedBy - healthcare service is invalid
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-invalid")},
+					},
 				},
 			},
 			shouldSucceed: false,
@@ -1992,24 +1972,20 @@ func TestValidateEndpointResourceReferencedByHealthcareService(t *testing.T) {
 					},
 				}: {},
 			},
-			allHealthcareServices: []fhir.BundleEntry{
+			allHealthcareServices: []fhir.HealthcareService{
 				{
-					Resource: mustMarshalJSON(&fhir.HealthcareService{
-						Id: to.Ptr("hcs-invalid"),
-						// Missing ProvidedBy - invalid
-						Endpoint: []fhir.Reference{
-							{Reference: to.Ptr("Endpoint/endpoint-mixed")},
-						},
-					}),
+					Id: to.Ptr("hcs-invalid"),
+					// Missing ProvidedBy - invalid
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-mixed")},
+					},
 				},
 				{
-					Resource: mustMarshalJSON(&fhir.HealthcareService{
-						Id:         to.Ptr("hcs-valid"),
-						ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
-						Endpoint: []fhir.Reference{
-							{Reference: to.Ptr("Endpoint/endpoint-mixed")},
-						},
-					}),
+					Id:         to.Ptr("hcs-valid"),
+					ProvidedBy: &fhir.Reference{Reference: to.Ptr("Organization/hospital-main")},
+					Endpoint: []fhir.Reference{
+						{Reference: to.Ptr("Endpoint/endpoint-mixed")},
+					},
 				},
 			},
 			shouldSucceed: true,


### PR DESCRIPTION
While debugging the mCSD Update Client I noticed that the list of healthcare services used for validation is passed around as a bundle entry, which means it must be unmarshalled before every use.