### PR TITLE
feat(pdp): use _elements in PIP patient read

### DIFF
--- a/component/pdp/pip.go
+++ b/component/pdp/pip.go
@@ -31,7 +31,7 @@ func (c *Component) enrichPolicyInputWithPIP(ctx context.Context, policyInput *P
 			Identifier []fhir.Identifier `json:"identifier"`
 		}
 		path := fmt.Sprintf("Patient/%s", policyInput.Context.PatientID)
-		err := client.Read(path, &patient, fhirclient.QueryParam("_elements", "identifier"))
+		err := client.ReadWithContext(ctx, path, &patient, fhirclient.QueryParam("_elements", "identifier"))
 		if err != nil {
 			slog.WarnContext(ctx, "Failed to get patient identifiers from PIP", logging.Error(err))
 			return policyInput, []ResultReason{


### PR DESCRIPTION
Fixes #426

- Add `_elements=identifier` query parameter to the PIP `Patient/<id>` read call
- Only the BSN identifier is needed for policy evaluation, no need to fetch the full Patient resource
- Narrow the deserialization target to an anonymous struct with only `Identifier`, making intent explicit and preventing accidental use of other Patient fields
- `_elements` is a [standard FHIR R4 parameter](https://hl7.org/fhir/R4/search.html#elements) — servers are not obliged to return just the requested elements, so they may return more. Servers [SHOULD ignore unknown/unsupported parameters](https://hl7.org/fhir/R4/search.html#errors) by default (lenient handling).