### PR TITLE
Fix edge case in ordering of PIP calls

### DIFF
--- a/component/pdp/component.go
+++ b/component/pdp/component.go
@@ -128,11 +128,10 @@ func (c *Component) HandleMainPolicy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Step 3: Enrich the policy input with data gathered from the policy information point (if available)
-	var resultReasons []ResultReason
-	policyInputTemplate, resultReasons = c.enrichPolicyInputWithPIP(r.Context(), policyInputTemplate)
-
+	policyInputTemplate, resultReasonsPIP := c.enrichPolicyInputWithPIP(r.Context(), policyInputTemplate)
 	// Step 4: Check consent at Mitz
-	policyInputTemplate, resultReasons = c.enrichPolicyInputWithMitz(r.Context(), policyInputTemplate)
+	policyInputTemplate, resultReasonsMitz := c.enrichPolicyInputWithMitz(r.Context(), policyInputTemplate)
+	resultReasons := slices.Concat(resultReasonsPIP, resultReasonsMitz)
 
 	// Evaluate all policies
 	for _, policyName := range policyNames {

--- a/component/pdp/pip.go
+++ b/component/pdp/pip.go
@@ -25,6 +25,13 @@ func (c *Component) enrichPolicyInputWithPIP(ctx context.Context, policyInput *P
 		}
 	}
 
+	policyInput, reasonsBSN := c.enrichBSN(ctx, policyInput)
+	policyInput, reasonsConsent := c.enrichConsent(ctx, policyInput)
+
+	return policyInput, slices.Concat(reasonsBSN, reasonsConsent)
+}
+
+func (c *Component) enrichBSN(ctx context.Context, policyInput *PolicyInput) (*PolicyInput, []ResultReason) {
 	// If we have a patientId try and fetch the BSN
 	if policyInput.Context.PatientID != "" && policyInput.Context.PatientBSN == "" {
 		client := c.pipClient
@@ -74,7 +81,10 @@ func (c *Component) enrichPolicyInputWithPIP(ctx context.Context, policyInput *P
 		}
 		policyInput.Context.PatientBSN = *bsn.Value
 	}
+	return policyInput, nil
+}
 
+func (c *Component) enrichConsent(ctx context.Context, policyInput *PolicyInput) (*PolicyInput, []ResultReason) {
 	// Check for local consent resources
 	if policyInput.Action.ConnectionTypeCode == "hl7-fhir-rest" &&
 		policyInput.Action.FHIRRest.InteractionType == fhir.TypeRestfulInteractionRead &&
@@ -209,6 +219,5 @@ func (c *Component) enrichPolicyInputWithPIP(ctx context.Context, policyInput *P
 			}
 		}
 	}
-
 	return policyInput, nil
 }


### PR DESCRIPTION
This PR address two problems in the code

1. When you have a patientID and the BSN check fails the code should continue with the local consent check anyway.
2. Result reasons weren't always returned properly

