### PR TITLE
fix(status): gate /status on real readiness to fix PDP startup race

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -44,10 +44,11 @@ func Start(ctx context.Context, config Config) error {
 		return errors.Wrap(err, "failed to create mCSD Update Client")
 	}
 	httpComponent := libHTTPComponent.New(config.HTTP, publicMux, internalMux)
+	statusComponent := status.New()
 	components := []component.Lifecycle{
 		mcsdUpdateClient,
 		mcsdadmin.New(config.MCSDAdmin),
-		status.New(),
+		statusComponent,
 		httpComponent,
 	}
 
@@ -118,6 +119,10 @@ func Start(ctx context.Context, config Config) error {
 		}
 		slog.DebugContext(ctx, "Component started", logging.Component(cmp))
 	}
+
+	// Mark the system ready only after all components have started, so /status
+	// doesn't report 200 before dependent state (e.g. PDP's OPA service) is initialized.
+	statusComponent.SetReady()
 
 	slog.DebugContext(ctx, "System started, waiting for shutdown...")
 	<-ctx.Done()

--- a/component/status/component.go
+++ b/component/status/component.go
@@ -3,6 +3,7 @@ package status
 import (
 	"context"
 	"net/http"
+	"sync/atomic"
 
 	"github.com/nuts-foundation/nuts-knooppunt/component"
 )
@@ -10,6 +11,7 @@ import (
 var _ component.Lifecycle = (*Component)(nil)
 
 type Component struct {
+	ready atomic.Bool
 }
 
 // New creates an instance of the status component, which provides a simple health check endpoint.
@@ -17,18 +19,30 @@ func New() *Component {
 	return &Component{}
 }
 
-func (c Component) Start() error {
-	// Nothing to do
+func (c *Component) Start() error {
 	return nil
 }
 
-func (c Component) Stop(ctx context.Context) error {
-	// Nothing to do
+func (c *Component) Stop(ctx context.Context) error {
+	c.ready.Store(false)
 	return nil
 }
 
-func (c Component) RegisterHttpHandlers(publicMux *http.ServeMux, internalMux *http.ServeMux) {
+// SetReady marks the system as ready, causing /status to return 200 OK.
+// Should be called after all components have been started, so readiness probes
+// don't report the system as up before its dependencies (e.g. PDP's OPA
+// service) are initialized.
+func (c *Component) SetReady() {
+	c.ready.Store(true)
+}
+
+func (c *Component) RegisterHttpHandlers(publicMux *http.ServeMux, internalMux *http.ServeMux) {
 	internalMux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		if !c.ready.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("starting"))
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("OK"))
 	})


### PR DESCRIPTION
## Summary
- `/status` was a trivial always-200 handler, so readiness probes reported ready as soon as the shared HTTP listener came up — before later components (notably PDP, which creates its OPA SDK in `Start()`) had finished initializing. Requests racing in that window hit a nil `opaService` and panicked, making `Test_BGZAuthorization` / `Test_EOverdrachtAuthorize` flaky.
- Add an atomic `ready` flag on the status component with a `SetReady()` method; `cmd.Start` flips it after the component Start loop completes. `/status` returns 503 \"starting\" until then.

Closes #480

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `go test ./component/pdp/... ./component/status/... ./cmd/...`
- [x] `go test -count=1 -run 'Test_BGZAuthorization|Test_EOverdrachtAuthorize' ./test/e2e/pdp/...` (3 consecutive runs, ~4s each, all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)