### PR TITLE
feat: mask BSNs in OPA decision logs and MITZ logs

### DIFF
--- a/component/mitz/component.go
+++ b/component/mitz/component.go
@@ -151,10 +151,10 @@ func (c *Component) CheckConsent(ctx context.Context, authzReq xacml.AuthzReques
 		return nil, fmt.Errorf("failed to create authorization decision query: %w", err)
 	}
 
-	// Log the XML request
+	// Log the XML request with every BSN-scoped InstanceIdentifier redacted.
 	slog.DebugContext(ctx, "Sending consent check request to MITZ",
 		slog.String("endpoint", c.consentCheckEndpoint),
-		slog.String("xmlPayload", authnDecisionQueryXml))
+		slog.String("xmlPayload", xacml.RedactBSN(authnDecisionQueryXml)))
 
 	// Create HTTP request with XML payload
 	httpReq, err := http.NewRequestWithContext(
@@ -185,14 +185,19 @@ func (c *Component) CheckConsent(ctx context.Context, authzReq xacml.AuthzReques
 		return nil, fmt.Errorf("failed to read consent check response: %w", err)
 	}
 
-	// Log response
+	// Redact every BSN-scoped InstanceIdentifier before the body touches a log
+	// or an error chain. MITZ echoes the resource-id (BSN) back in the response
+	// because IncludeInResult="true" is set on the request, and may also include
+	// BSNs we never sent (e.g. of a legal representative).
+	redactedBody := xacml.RedactBSN(string(responseBody))
+
 	slog.DebugContext(ctx, "Received consent check response from MITZ",
 		slog.Int("statusCode", resp.StatusCode),
-		slog.String("responseBody", string(responseBody)))
+		slog.String("responseBody", redactedBody))
 
 	// Check for non-2xx status
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("consent check failed with status %d: %s", resp.StatusCode, string(responseBody))
+		return nil, fmt.Errorf("consent check failed with status %d: %s", resp.StatusCode, redactedBody)
 	}
 
 	// Parse the XACML response to extract the decision
@@ -408,3 +413,4 @@ func (c *Component) handleSubscribe(httpResponse http.ResponseWriter, httpReques
 	// so we trust that if CreateWithContext succeeds, the subscription was accepted
 	fhirapi.SendResponse(httpRequest.Context(), httpResponse, http.StatusCreated, resource)
 }
+

--- a/component/mitz/xacml/redact.go
+++ b/component/mitz/xacml/redact.go
@@ -12,13 +12,15 @@ const redactedExtension = `extension="[REDACTED]"`
 // They match InstanceIdentifier elements scoped to the BSN root OID and
 // rewrite only the `extension` attribute, leaving sibling attributes intact.
 // Redaction is keyed on the root OID (not on a known BSN value) so BSNs
-// echoed back by MITZ that we never sent ourselves are also scrubbed.
+// echoed back by MITZ that were never sent in the original request are
+// also scrubbed.
 var (
+	bsnOIDPattern            = regexp.QuoteMeta(BSNRootOID)
 	reBSNExtensionBeforeRoot = regexp.MustCompile(
-		`extension="[^"]*"(\s+(?:[A-Za-z:][A-Za-z0-9:]*="[^"]*"\s+)*root="2\.16\.840\.1\.113883\.2\.4\.6\.3")`,
+		`extension="[^"]*"(\s+(?:[A-Za-z:][A-Za-z0-9:]*="[^"]*"\s+)*root="` + bsnOIDPattern + `")`,
 	)
 	reBSNRootBeforeExtension = regexp.MustCompile(
-		`(root="2\.16\.840\.1\.113883\.2\.4\.6\.3"(?:\s+[A-Za-z:][A-Za-z0-9:]*="[^"]*")*\s+)extension="[^"]*"`,
+		`(root="` + bsnOIDPattern + `"(?:\s+[A-Za-z:][A-Za-z0-9:]*="[^"]*")*\s+)extension="[^"]*"`,
 	)
 )
 

--- a/component/mitz/xacml/redact.go
+++ b/component/mitz/xacml/redact.go
@@ -2,10 +2,6 @@ package xacml
 
 import "regexp"
 
-// BSNRootOID is the HL7 root OID identifying a BSN (Dutch social security number)
-// inside an HL7 InstanceIdentifier element.
-const BSNRootOID = "2.16.840.1.113883.2.4.6.3"
-
 const redactedExtension = `extension="[REDACTED]"`
 
 // Two patterns cover both attribute orderings XACML emitters may produce.

--- a/component/mitz/xacml/redact.go
+++ b/component/mitz/xacml/redact.go
@@ -1,0 +1,35 @@
+package xacml
+
+import "regexp"
+
+// BSNRootOID is the HL7 root OID identifying a BSN (Dutch social security number)
+// inside an HL7 InstanceIdentifier element.
+const BSNRootOID = "2.16.840.1.113883.2.4.6.3"
+
+const redactedExtension = `extension="[REDACTED]"`
+
+// Two patterns cover both attribute orderings XACML emitters may produce.
+// They match InstanceIdentifier elements scoped to the BSN root OID and
+// rewrite only the `extension` attribute, leaving sibling attributes intact.
+// Redaction is keyed on the root OID (not on a known BSN value) so BSNs
+// echoed back by MITZ that we never sent ourselves are also scrubbed.
+var (
+	reBSNExtensionBeforeRoot = regexp.MustCompile(
+		`extension="[^"]*"(\s+(?:[A-Za-z:][A-Za-z0-9:]*="[^"]*"\s+)*root="2\.16\.840\.1\.113883\.2\.4\.6\.3")`,
+	)
+	reBSNRootBeforeExtension = regexp.MustCompile(
+		`(root="2\.16\.840\.1\.113883\.2\.4\.6\.3"(?:\s+[A-Za-z:][A-Za-z0-9:]*="[^"]*")*\s+)extension="[^"]*"`,
+	)
+)
+
+// RedactBSN returns the given XACML payload with every BSN extension value
+// stripped from HL7 InstanceIdentifier elements that are scoped to the BSN
+// root OID. The result is safe to write to logs.
+func RedactBSN(xmlPayload string) string {
+	if xmlPayload == "" {
+		return ""
+	}
+	out := reBSNExtensionBeforeRoot.ReplaceAllString(xmlPayload, redactedExtension+`$1`)
+	out = reBSNRootBeforeExtension.ReplaceAllString(out, `${1}`+redactedExtension)
+	return out
+}

--- a/component/mitz/xacml/redact_test.go
+++ b/component/mitz/xacml/redact_test.go
@@ -22,7 +22,14 @@ func TestRedactBSN_RequestXML(t *testing.T) {
 	}
 	xml, err := CreateAuthzDecisionQuery(req)
 	require.NoError(t, err)
-	require.Contains(t, xml, "900186021")
+
+	// Serializer-shape guard: RedactBSN's regexes assume the current etree
+	// serialization (double-quoted attributes, no spaces around `=`, bare
+	// local-name attributes). If a future change to the serializer breaks any
+	// of these assumptions this assertion fails first, naming the cause
+	// rather than having the redaction assertion fail ambiguously.
+	require.Contains(t, xml, `extension="900186021"`, "serializer shape drift: expected double-quoted attribute without spaces")
+	require.Contains(t, xml, `root="`+BSNRootOID+`"`, "serializer shape drift: expected bare root attribute with BSN OID")
 
 	redacted := RedactBSN(xml)
 
@@ -33,6 +40,34 @@ func TestRedactBSN_RequestXML(t *testing.T) {
 	assert.Contains(t, redacted, "000095254", "ProviderID must be preserved")
 	assert.Contains(t, redacted, "00000666", "ProviderInstitutionID must be preserved")
 	assert.Contains(t, redacted, "XACMLAuthzDecisionQuery")
+}
+
+// The signed request path adds an XML-DSig Signature element to the XACML
+// query. Redaction must keep working on that serialized output.
+func TestRedactBSN_SignedRequestXML(t *testing.T) {
+	signingConfig := generateTestSigningConfig(t)
+	req := AuthzRequest{
+		PatientBSN:             "900186021",
+		HealthcareFacilityType: "Z3",
+		AuthorInstitutionID:    "00000659",
+		EventCode:              "GGC002",
+		SubjectRole:            "01.015",
+		ProviderID:             "000095254",
+		ProviderInstitutionID:  "00000666",
+		ConsultingFacilityType: "Z3",
+		PurposeOfUse:           "TREAT",
+	}
+	xml, err := CreateSignedAuthzDecisionQuery(req, signingConfig)
+	require.NoError(t, err)
+	require.Contains(t, xml, "900186021")
+	require.Contains(t, xml, "ds:SignedInfo", "sanity: signed path must produce a Signature element")
+
+	redacted := RedactBSN(xml)
+
+	assert.NotContains(t, redacted, "900186021", "BSN must not appear in redacted signed payload")
+	assert.Contains(t, redacted, "[REDACTED]")
+	assert.Contains(t, redacted, "ds:SignedInfo", "signature structure must be preserved")
+	assert.Contains(t, redacted, "00000659", "non-BSN identifiers must be preserved")
 }
 
 func TestRedactBSN_ForeignBSNInResponse(t *testing.T) {

--- a/component/mitz/xacml/redact_test.go
+++ b/component/mitz/xacml/redact_test.go
@@ -1,0 +1,80 @@
+package xacml
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactBSN_RequestXML(t *testing.T) {
+	req := AuthzRequest{
+		PatientBSN:             "900186021",
+		HealthcareFacilityType: "Z3",
+		AuthorInstitutionID:    "00000659",
+		EventCode:              "GGC002",
+		SubjectRole:            "01.015",
+		ProviderID:             "000095254",
+		ProviderInstitutionID:  "00000666",
+		ConsultingFacilityType: "Z3",
+		PurposeOfUse:           "TREAT",
+	}
+	xml, err := CreateAuthzDecisionQuery(req)
+	require.NoError(t, err)
+	require.Contains(t, xml, "900186021")
+
+	redacted := RedactBSN(xml)
+
+	assert.NotContains(t, redacted, "900186021", "BSN must not appear in redacted output")
+	assert.Contains(t, redacted, "[REDACTED]")
+	// Non-BSN identifiers must be preserved so the log remains useful for debugging.
+	assert.Contains(t, redacted, "00000659", "AuthorInstitutionID must be preserved")
+	assert.Contains(t, redacted, "000095254", "ProviderID must be preserved")
+	assert.Contains(t, redacted, "00000666", "ProviderInstitutionID must be preserved")
+	assert.Contains(t, redacted, "XACMLAuthzDecisionQuery")
+}
+
+func TestRedactBSN_ForeignBSNInResponse(t *testing.T) {
+	// MITZ echoes the resource-id (BSN) attribute back when IncludeInResult=true,
+	// and may include BSNs we did not send ourselves (e.g. legal representative).
+	// Redaction is keyed on the root OID, not the BSN value, so foreign BSNs are
+	// also scrubbed.
+	responseXML := `<Response><InstanceIdentifier extension="999888777" root="2.16.840.1.113883.2.4.6.3" xmlns="urn:hl7-org:v3"/></Response>`
+	redacted := RedactBSN(responseXML)
+	assert.NotContains(t, redacted, "999888777")
+	assert.Contains(t, redacted, `extension="[REDACTED]"`)
+}
+
+func TestRedactBSN_LeavesOtherOIDsAlone(t *testing.T) {
+	xml := `<Root><InstanceIdentifier extension="12345" root="2.16.528.1.1007.3.3" xmlns="urn:hl7-org:v3"/></Root>`
+	redacted := RedactBSN(xml)
+	assert.Contains(t, redacted, `extension="12345"`, "non-BSN OIDs must not be redacted")
+}
+
+func TestRedactBSN_Empty(t *testing.T) {
+	assert.Equal(t, "", RedactBSN(""))
+}
+
+func TestRedactBSN_XMLWithoutBSNIsUntouched(t *testing.T) {
+	input := `<Envelope><Body>unrelated content</Body></Envelope>`
+	assert.Equal(t, input, RedactBSN(input))
+}
+
+func TestRedactBSN_RootBeforeExtensionOrdering(t *testing.T) {
+	xml := `<Root><InstanceIdentifier root="2.16.840.1.113883.2.4.6.3" extension="900186021" xmlns="urn:hl7-org:v3"/></Root>`
+	redacted := RedactBSN(xml)
+	assert.NotContains(t, redacted, "900186021")
+	assert.Contains(t, redacted, `extension="[REDACTED]"`)
+}
+
+func TestRedactBSN_MultipleBSNElements(t *testing.T) {
+	xml := `<Root>` +
+		`<InstanceIdentifier extension="900186021" root="2.16.840.1.113883.2.4.6.3" xmlns="urn:hl7-org:v3"/>` +
+		`<InstanceIdentifier extension="900186022" root="2.16.840.1.113883.2.4.6.3" xmlns="urn:hl7-org:v3"/>` +
+		`</Root>`
+	redacted := RedactBSN(xml)
+	assert.NotContains(t, redacted, "900186021")
+	assert.NotContains(t, redacted, "900186022")
+	assert.Equal(t, 2, strings.Count(redacted, `extension="[REDACTED]"`))
+}

--- a/component/mitz/xacml/xacml.go
+++ b/component/mitz/xacml/xacml.go
@@ -12,6 +12,10 @@ import (
 	dsig "github.com/russellhaering/goxmldsig"
 )
 
+// BSNRootOID is the HL7 root OID identifying a BSN (Dutch social security number)
+// inside an HL7 InstanceIdentifier element.
+const BSNRootOID = "2.16.840.1.113883.2.4.6.3"
+
 // CreateAuthzDecisionQuery generates an unsigned SOAP envelope containing an XACML authorization decision query
 // based on the example.xml structure
 func CreateAuthzDecisionQuery(req AuthzRequest) (string, error) {
@@ -72,7 +76,7 @@ func createAuthzDecisionQuery(req AuthzRequest, signingConfig *SigningConfig) (s
 	// Resource ID (Patient BSN)
 	addHL7InstanceIdentifierAttribute(resourceAttrs,
 		"urn:oasis:names:tc:xacml:2.0:resource:resource-id",
-		"2.16.840.1.113883.2.4.6.3",
+		BSNRootOID,
 		req.PatientBSN)
 
 	// Healthcare Facility Type

--- a/component/pdp/component.go
+++ b/component/pdp/component.go
@@ -86,7 +86,6 @@ func (c *Component) RegisterHttpHandlers(publicMux *http.ServeMux, internalMux *
 func (c *Component) HandleMainPolicy(w http.ResponseWriter, r *http.Request) {
 	var reqBody APIRequest
 	err := json.NewDecoder(r.Body).Decode(&reqBody)
-	input := reqBody.Input
 	if err != nil {
 		writeResponseWithCode(r.Context(), w, APIResponse{
 			Error:    "unable to parse request body: " + err.Error(),
@@ -94,6 +93,7 @@ func (c *Component) HandleMainPolicy(w http.ResponseWriter, r *http.Request) {
 		}, http.StatusBadRequest)
 		return
 	}
+	input := reqBody.Input
 
 	scopes := strings.Fields(input.Subject.Scope)
 
@@ -107,8 +107,9 @@ func (c *Component) HandleMainPolicy(w http.ResponseWriter, r *http.Request) {
 	slices.Sort(policyNames)
 
 	// Step 1: Providing a policy is required for every PDP request. We can short-circuit here, no need to process the request.
+	// The `system` bundle hosts OPA infrastructure rules (e.g. decision-log masking) and is not directly invokable.
 	for _, policyName := range policyNames {
-		if strings.HasPrefix(policyName, "test_") {
+		if strings.HasPrefix(policyName, "test_") || policyName == "system" {
 			writeResponseWithCode(r.Context(), w, APIResponse{
 				Error:    fmt.Sprintf("policy not allowed: %s", policyName),
 				Policies: map[string]PolicyResult{},

--- a/component/pdp/component_test.go
+++ b/component/pdp/component_test.go
@@ -551,6 +551,24 @@ func TestHandleMainPolicy_Integration(t *testing.T) {
 		assert.False(t, response.Allow)
 		assert.Contains(t, response.Error, "policy not allowed")
 	})
+	t.Run("system policy - blocked at handler", func(t *testing.T) {
+		// The `system` bundle hosts OPA infrastructure (decision-log masking) and is not invokable as a policy.
+		body, _ := json.Marshal(APIRequest{
+			Input: APIInput{
+				Subject: APISubject{Scope: "system"},
+				Request: HTTPRequest{Method: "GET", Path: "/Patient"},
+				Context: APIContext{ConnectionTypeCode: "hl7-fhir-rest"},
+			},
+		})
+		req := httptest.NewRequest("POST", "/pdp", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		service.HandleMainPolicy(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		var response APIResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&response))
+		assert.False(t, response.Allow)
+		assert.Contains(t, response.Error, "policy not allowed")
+	})
 	t.Run("test_search_params policy - search param AND/OR via evalRegoPolicy", func(t *testing.T) {
 		type testCase struct {
 			name     string

--- a/component/pdp/opa_test.go
+++ b/component/pdp/opa_test.go
@@ -5,12 +5,17 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
+	"github.com/nuts-foundation/nuts-knooppunt/component/pdp/policies"
 	"github.com/nuts-foundation/nuts-knooppunt/lib/logging"
+	"github.com/nuts-foundation/nuts-knooppunt/lib/to"
+	"github.com/open-policy-agent/opa/v1/sdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 )
 
 // captureHandler is a slog.Handler that records all log messages for inspection.
@@ -41,6 +46,25 @@ func (h *captureHandler) messages() []string {
 		msgs[i] = r.Message
 	}
 	return msgs
+}
+
+// allText renders every captured record — message plus every attribute value —
+// as a single string, so tests can grep for sensitive substrings that may
+// appear either in the log message or in any structured attribute.
+func (h *captureHandler) allText() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var b strings.Builder
+	for _, r := range h.records {
+		b.WriteString(r.Message)
+		b.WriteByte('\n')
+		r.Attrs(func(a slog.Attr) bool {
+			b.WriteString(a.Value.String())
+			b.WriteByte('\n')
+			return true
+		})
+	}
+	return b.String()
 }
 
 func TestOPALogsGoThroughSlog(t *testing.T) {
@@ -79,4 +103,99 @@ func TestOPALogsGoThroughSlog(t *testing.T) {
 	}
 	assert.True(t, hasBundleLog,
 		"expected OPA log messages to go through slog, but none were captured. Got messages: %v", msgs)
+}
+
+// TestOPADecisionLogsMaskBSN asserts that OPA's decision-log plugin finds and
+// applies `data.system.log.mask` from the embedded `system` bundle: the BSN
+// and other known BSN-bearing fields must not appear in the captured log
+// stream, and the [REDACTED] placeholder must appear instead. This proves the
+// whole chain (bundle load → decision → mask → ConsoleLogger → slog) works
+// end-to-end, not just the rego rule in isolation.
+func TestOPADecisionLogsMaskBSN(t *testing.T) {
+	handler := &captureHandler{}
+	originalDefault := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	defer slog.SetDefault(originalDefault)
+	logging.InitLogrus()
+
+	bundles, err := policies.Bundles(t.Context())
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /pdp/bundles/{policyName}", func(w http.ResponseWriter, r *http.Request) {
+		policyName := strings.TrimSuffix(r.PathValue("policyName"), ".tar.gz")
+		data, found := bundles[policyName]
+		if !found {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(data)
+	})
+	httpServer := httptest.NewServer(mux)
+	defer httpServer.Close()
+
+	opaService, err := createOPAService(t.Context(), httpServer.URL+"/pdp/bundles/", bundles)
+	require.NoError(t, err)
+	defer opaService.Stop(t.Context())
+
+	// Build a fully-populated PolicyInput from the Go struct (not a hand-rolled
+	// map) so this test fails if a future struct change adds a BSN-bearing
+	// field that the mask rego doesn't cover. Every field that can carry a BSN
+	// or BSN-scoped identifier must contain `bsnSentinel`; we then assert the
+	// sentinel never appears anywhere in the captured log stream.
+	const bsnSentinel = "900186021"
+	patientType := fhir.ResourceTypePatient
+	policyInput := PolicyInput{
+		Context: PolicyContext{
+			PatientBSN:   bsnSentinel,
+			PatientID:    "patient-123",
+			MitzConsent:  true,
+			PurposeOfUse: "TREAT",
+		},
+		Subject: PolicySubject{
+			OtherProps: OtherProps{
+				"patient_enrollment_identifier": "http://fhir.nl/fhir/NamingSystem/bsn|" + bsnSentinel,
+			},
+		},
+		Resource: PolicyResource{
+			Type: &patientType,
+			Content: map[string]any{
+				"resourceType": "Patient",
+				"identifier": []map[string]any{
+					{"system": "http://fhir.nl/fhir/NamingSystem/bsn", "value": bsnSentinel},
+				},
+			},
+		},
+		Action: PolicyAction{
+			Request: HTTPRequest{
+				Method: "GET",
+				Path:   "/Patient",
+				Query:  "identifier=http://fhir.nl/fhir/NamingSystem/bsn|" + bsnSentinel,
+				Body:   `{"identifier":[{"system":"http://fhir.nl/fhir/NamingSystem/bsn","value":"` + bsnSentinel + `"}]}`,
+				Header: http.Header{"Authorization": []string{"Bearer token-" + bsnSentinel}},
+			},
+			FHIRRest: FHIRRestData{
+				CapabilityChecked: true,
+				Include:           []string{"Patient:general-practitioner"},
+				SearchParams: map[string][][]string{
+					"identifier": {{"http://fhir.nl/fhir/NamingSystem/bsn|" + bsnSentinel}},
+				},
+			},
+		},
+	}
+
+	input, err := to.JSONMap(policyInput)
+	require.NoError(t, err)
+	_, err = opaService.Decision(t.Context(), sdk.DecisionOptions{Path: "/bgz", Input: input})
+	require.NoError(t, err)
+
+	captured := handler.allText()
+	// Guard: the assertions below only prove anything if the decision-log
+	// message actually landed in our capture buffer. "Decision Log" is the
+	// literal log message emitted by OPA's console decision-log plugin.
+	require.Contains(t, captured, "Decision Log",
+		"decision log was not captured; the mask assertions below would be vacuously true")
+	assert.NotContains(t, captured, bsnSentinel, "BSN must not appear anywhere in decision logs")
+	assert.Contains(t, captured, "[REDACTED]", "expected at least one field to be redacted")
 }

--- a/component/pdp/policies/system/policy.rego
+++ b/component/pdp/policies/system/policy.rego
@@ -28,18 +28,28 @@ mask contains {"op": "upsert", "path": "/input/context/patient_bsn", "value": re
 }
 
 mask contains {"op": "upsert", "path": "/input/subject/patient_enrollment_identifier", "value": redacted} if {
-	is_bsn_scoped(input.input.subject.patient_enrollment_identifier)
+	is_bsn(input.input.subject.patient_enrollment_identifier)
+}
+
+mask contains {"op": "upsert", "path": "/input/subject/patient_enrollment_identifier", "value": redacted} if {
+	is_potential_bsn(input.input.subject.patient_enrollment_identifier)
 }
 
 # --- Structured redactions: search params ----------------------------------
-# search_params.identifier is a [][]string; when any value is BSN-scoped we
-# replace the whole key with a placeholder (rather than removing it) so the
-# log still shows the field was present and deliberately redacted.
+# search_params.identifier is a [][]string; when any value looks like a BSN
+# we replace the whole key with a placeholder (rather than removing it) so
+# the log still shows the field was present and deliberately redacted.
 
 mask contains {"op": "upsert", "path": "/input/action/fhir_rest/search_params/identifier", "value": redacted} if {
 	some and_group in input.input.action.fhir_rest.search_params.identifier
 	some value in and_group
-	is_bsn_scoped(value)
+	is_bsn(value)
+}
+
+mask contains {"op": "upsert", "path": "/input/action/fhir_rest/search_params/identifier", "value": redacted} if {
+	some and_group in input.input.action.fhir_rest.search_params.identifier
+	some value in and_group
+	is_potential_bsn(value)
 }
 
 # --- Wholesale redactions: debug-only fields that can embed BSNs -----------
@@ -48,7 +58,7 @@ mask contains {"op": "upsert", "path": "/input/action/fhir_rest/search_params/id
 # bodies, URL-encoded identifiers, chained FHIR search params, etc.) is an
 # endless arms race, so we replace the whole value with a placeholder. The
 # key stays so readers can see the field existed but was deliberately
-# redacted — and a future use case could swap to selective masking without
+# redacted, and a future use case could swap to selective masking without
 # restructuring the decision-log event shape.
 
 mask contains {"op": "upsert", "path": "/input/action/request/query", "value": redacted} if {
@@ -68,19 +78,44 @@ mask contains {"op": "upsert", "path": "/input/resource/content", "value": redac
 }
 
 # --- Helpers ---------------------------------------------------------------
-# `is_string` guards against fail-open: without it, a non-string value would
-# raise a type error from startswith, the rule body would become undefined
-# and OPA would log the decision event unmasked.
+# `is_string` guards against fail-open: without it a non-string value would
+# raise a type error, the rule body would be undefined, and OPA would log
+# the decision event unmasked.
 # URN comparison is case-insensitive per RFC 8141; FHIR URIs are case-
 # sensitive per spec, but accepting case-insensitive matching here is a
 # defensive choice for a log-scrubber.
 
-is_bsn_scoped(s) if {
+is_bsn(s) if {
 	is_string(s)
 	startswith(lower(s), sprintf("%s|", [lower(bsn_system_uri)]))
 }
 
-is_bsn_scoped(s) if {
+is_bsn(s) if {
 	is_string(s)
 	startswith(lower(s), sprintf("%s|", [lower(bsn_system_oid)]))
+}
+
+# is_potential_bsn matches an identifier value carrying a BSN without the
+# system attached: either the `|<value>` form (empty system) or a bare
+# `<value>`. Spec-compliant Dutch FHIR clients always include the system, so
+# this only fires on anomalous input. Requiring a 9-digit number that passes
+# the eleven-check keeps false positives low: UZI-zorgverlener is 9 digits
+# but has no checksum, AGB and URA are 8 digits, and roughly 1 in 11 random
+# 9-digit numbers happens to pass.
+is_potential_bsn(s) if {
+	is_string(s)
+	is_valid_bsn_checksum(trim_prefix(s, "|"))
+}
+
+# Dutch BSN eleven-check: sum of 9·d1 + 8·d2 + ... + 2·d8 + (-1)·d9 must be
+# divisible by 11. See https://nl.wikipedia.org/wiki/Burgerservicenummer#Elfproef
+bsn_weights := [9, 8, 7, 6, 5, 4, 3, 2, -1]
+
+is_valid_bsn_checksum(s) if {
+	regex.match(`^[0-9]{9}$`, s)
+	products := [p |
+		i := [0, 1, 2, 3, 4, 5, 6, 7, 8][_]
+		p := bsn_weights[i] * to_number(substring(s, i, 1))
+	]
+	sum(products) % 11 == 0
 }

--- a/component/pdp/policies/system/policy.rego
+++ b/component/pdp/policies/system/policy.rego
@@ -1,0 +1,86 @@
+# The directory is flat (`system/`) because the bundler in
+# component/pdp/policies/bundler.go requires `{policyName}/policy.rego` at the
+# top level of each policy directory; nesting as `system/log/` would break
+# bundle generation.
+# regal ignore:directory-package-mismatch
+package system.log
+
+import rego.v1
+
+# mask redacts BSNs (Dutch social security numbers) from OPA decision logs.
+# OPA calls this rule for every decision event with the event as `input`, so
+# the original decision input lives at `input.input`. The rule returns
+# JSON-Patch operations describing what to redact.
+# See https://www.openpolicyagent.org/docs/management-decision-logs#masking-sensitive-data
+
+redacted := "[REDACTED]"
+
+# FHIR NamingSystem URI and equivalent HL7 OID that identify a BSN. Identifiers
+# scoped to other systems (URA, AGB, etc.) are left untouched.
+bsn_system_uri := "http://fhir.nl/fhir/NamingSystem/bsn"
+
+bsn_system_oid := "urn:oid:2.16.840.1.113883.2.4.6.3"
+
+# --- Scalar redactions: known BSN-bearing fields ----------------------------
+
+mask contains {"op": "upsert", "path": "/input/context/patient_bsn", "value": redacted} if {
+	input.input.context.patient_bsn != ""
+}
+
+mask contains {"op": "upsert", "path": "/input/subject/patient_enrollment_identifier", "value": redacted} if {
+	is_bsn_scoped(input.input.subject.patient_enrollment_identifier)
+}
+
+# --- Structured redactions: search params ----------------------------------
+# search_params.identifier is a [][]string; when any value is BSN-scoped we
+# replace the whole key with a placeholder (rather than removing it) so the
+# log still shows the field was present and deliberately redacted.
+
+mask contains {"op": "upsert", "path": "/input/action/fhir_rest/search_params/identifier", "value": redacted} if {
+	some and_group in input.input.action.fhir_rest.search_params.identifier
+	some value in and_group
+	is_bsn_scoped(value)
+}
+
+# --- Wholesale redactions: debug-only fields that can embed BSNs -----------
+# These fields are not read by any policy; they exist in the decision input
+# only for traceability. Redacting specific BSN shapes inside them (JSON
+# bodies, URL-encoded identifiers, chained FHIR search params, etc.) is an
+# endless arms race, so we replace the whole value with a placeholder. The
+# key stays so readers can see the field existed but was deliberately
+# redacted — and a future use case could swap to selective masking without
+# restructuring the decision-log event shape.
+
+mask contains {"op": "upsert", "path": "/input/action/request/query", "value": redacted} if {
+	input.input.action.request.query != ""
+}
+
+mask contains {"op": "upsert", "path": "/input/action/request/body", "value": redacted} if {
+	input.input.action.request.body != ""
+}
+
+mask contains {"op": "upsert", "path": "/input/action/request/header", "value": redacted} if {
+	count(input.input.action.request.header) > 0
+}
+
+mask contains {"op": "upsert", "path": "/input/resource/content", "value": redacted} if {
+	input.input.resource.content
+}
+
+# --- Helpers ---------------------------------------------------------------
+# `is_string` guards against fail-open: without it, a non-string value would
+# raise a type error from startswith, the rule body would become undefined
+# and OPA would log the decision event unmasked.
+# URN comparison is case-insensitive per RFC 8141; FHIR URIs are case-
+# sensitive per spec, but accepting case-insensitive matching here is a
+# defensive choice for a log-scrubber.
+
+is_bsn_scoped(s) if {
+	is_string(s)
+	startswith(lower(s), sprintf("%s|", [lower(bsn_system_uri)]))
+}
+
+is_bsn_scoped(s) if {
+	is_string(s)
+	startswith(lower(s), sprintf("%s|", [lower(bsn_system_oid)]))
+}

--- a/component/pdp/policies/system/policy_test.rego
+++ b/component/pdp/policies/system/policy_test.rego
@@ -5,7 +5,9 @@ import rego.v1
 import data.system.log
 
 # The mask rule receives the full decision event; the original input sits at
-# `input.input`. These fixtures mirror that structure.
+# `input.input`. `evt(override)` folds an override into the base event shape.
+# Tests evaluate `log.mask` with that event, then use `has_redaction` /
+# `any_patch_for_path` to assert outcomes. `with` stays inside each test.
 
 base_event := {
 	"path": "/bgz",
@@ -17,76 +19,142 @@ base_event := {
 	},
 }
 
+evt(override) := object.union(base_event, {"input": override})
+
+has_redaction(patches, path) if {
+	{"op": "upsert", "path": path, "value": "[REDACTED]"} in patches
+}
+
 # --- patient_bsn -----------------------------------------------------------
 
+bsn_path := "/input/context/patient_bsn"
+
 test_redacts_patient_bsn if {
-	event := object.union(base_event, {"input": {"context": {"patient_bsn": "123456789"}}})
-	{"op": "upsert", "path": "/input/context/patient_bsn", "value": "[REDACTED]"} in log.mask with input as event
+	patches := log.mask with input as evt({"context": {"patient_bsn": "123456789"}})
+	has_redaction(patches, bsn_path)
 }
 
 test_no_patch_when_patient_bsn_absent if {
 	patches := log.mask with input as base_event
-	not any_patch_for_path(patches, "/input/context/patient_bsn")
+	not any_patch_for_path(patches, bsn_path)
 }
 
 test_no_patch_when_patient_bsn_empty if {
-	event := object.union(base_event, {"input": {"context": {"patient_bsn": ""}}})
-	patches := log.mask with input as event
-	not any_patch_for_path(patches, "/input/context/patient_bsn")
+	patches := log.mask with input as evt({"context": {"patient_bsn": ""}})
+	not any_patch_for_path(patches, bsn_path)
 }
 
 # --- patient_enrollment_identifier ----------------------------------------
 
+enrollment_path := "/input/subject/patient_enrollment_identifier"
+
+enrollment(value) := {"subject": {"patient_enrollment_identifier": value}}
+
 test_redacts_patient_enrollment_identifier_uri_system if {
-	event := object.union(base_event, {"input": {"subject": {"patient_enrollment_identifier": "http://fhir.nl/fhir/NamingSystem/bsn|123456789"}}})
-	{"op": "upsert", "path": "/input/subject/patient_enrollment_identifier", "value": "[REDACTED]"} in log.mask with input as event
+	patches := log.mask with input as evt(enrollment("http://fhir.nl/fhir/NamingSystem/bsn|123456789"))
+	has_redaction(patches, enrollment_path)
 }
 
 test_redacts_patient_enrollment_identifier_oid_system if {
-	event := object.union(base_event, {"input": {"subject": {"patient_enrollment_identifier": "urn:oid:2.16.840.1.113883.2.4.6.3|123456789"}}})
-	{"op": "upsert", "path": "/input/subject/patient_enrollment_identifier", "value": "[REDACTED]"} in log.mask with input as event
+	patches := log.mask with input as evt(enrollment("urn:oid:2.16.840.1.113883.2.4.6.3|123456789"))
+	has_redaction(patches, enrollment_path)
 }
 
 test_keeps_non_bsn_enrollment_identifier_untouched if {
-	event := object.union(base_event, {"input": {"subject": {"patient_enrollment_identifier": "http://fhir.nl/fhir/NamingSystem/ura|12345"}}})
-	patches := log.mask with input as event
-	not any_patch_for_path(patches, "/input/subject/patient_enrollment_identifier")
+	patches := log.mask with input as evt(enrollment("http://fhir.nl/fhir/NamingSystem/ura|12345"))
+	not any_patch_for_path(patches, enrollment_path)
+}
+
+# --- Anomalous FHIR syntax: systemless (|<value>) and bare (<value>) -------
+# The eleven-check keeps false positives low against 8-digit AGB/URA and
+# 9-digit UZI numbers (UZI has no checksum).
+
+test_redacts_systemless_bsn_with_pipe_prefix if {
+	patches := log.mask with input as evt(enrollment("|900186021"))
+	has_redaction(patches, enrollment_path)
+}
+
+test_redacts_bare_bsn_without_pipe if {
+	patches := log.mask with input as evt(enrollment("900186021"))
+	has_redaction(patches, enrollment_path)
+}
+
+test_keeps_unscoped_invalid_checksum_untouched if {
+	patches := log.mask with input as evt(enrollment("|123456789"))
+	not any_patch_for_path(patches, enrollment_path)
+}
+
+# UZI-zorgverlener has the same length as a BSN but no eleven-check; a
+# UZI-shaped number that fails the check must be left visible in logs.
+test_keeps_uzi_shaped_non_elfproef_value_untouched if {
+	patches := log.mask with input as evt(enrollment("123456780"))
+	not any_patch_for_path(patches, enrollment_path)
+}
+
+test_keeps_unscoped_eight_digit_value_untouched if {
+	patches := log.mask with input as evt(enrollment("|12345678"))
+	not any_patch_for_path(patches, enrollment_path)
+}
+
+test_keeps_empty_pipe_only_untouched if {
+	patches := log.mask with input as evt(enrollment("|"))
+	not any_patch_for_path(patches, enrollment_path)
+}
+
+test_keeps_multi_pipe_value_untouched if {
+	patches := log.mask with input as evt(enrollment("|900186021|extra"))
+	not any_patch_for_path(patches, enrollment_path)
+}
+
+# BSNs are issued starting at 100000000; a leading-zero value is not a real
+# citizen BSN. 012345672 passes eleven-check so we still redact: over-redact
+# rather than leak.
+test_redacts_leading_zero_valid_checksum if {
+	patches := log.mask with input as evt(enrollment("012345672"))
+	has_redaction(patches, enrollment_path)
 }
 
 # --- search_params.identifier ---------------------------------------------
 
+search_identifier_path := "/input/action/fhir_rest/search_params/identifier"
+
+search_params(values) := {"action": {"fhir_rest": {"search_params": {"identifier": values}}}}
+
 test_redacts_search_params_identifier_uri_system if {
-	event := object.union(base_event, {"input": {"action": {"fhir_rest": {"search_params": {"identifier": [["http://fhir.nl/fhir/NamingSystem/bsn|123456789"]]}}}}})
-	{"op": "upsert", "path": "/input/action/fhir_rest/search_params/identifier", "value": "[REDACTED]"} in log.mask with input as event
+	patches := log.mask with input as evt(search_params([["http://fhir.nl/fhir/NamingSystem/bsn|123456789"]]))
+	has_redaction(patches, search_identifier_path)
 }
 
 test_redacts_search_params_identifier_oid_system if {
-	event := object.union(base_event, {"input": {"action": {"fhir_rest": {"search_params": {"identifier": [["urn:oid:2.16.840.1.113883.2.4.6.3|123456789"]]}}}}})
-	{"op": "upsert", "path": "/input/action/fhir_rest/search_params/identifier", "value": "[REDACTED]"} in log.mask with input as event
+	patches := log.mask with input as evt(search_params([["urn:oid:2.16.840.1.113883.2.4.6.3|123456789"]]))
+	has_redaction(patches, search_identifier_path)
 }
 
 test_redacts_identifier_when_bsn_is_second_or_value if {
-	event := object.union(base_event, {"input": {"action": {"fhir_rest": {"search_params": {"identifier": [["http://fhir.nl/fhir/NamingSystem/ura|12345", "http://fhir.nl/fhir/NamingSystem/bsn|123456789"]]}}}}})
-	{"op": "upsert", "path": "/input/action/fhir_rest/search_params/identifier", "value": "[REDACTED]"} in log.mask with input as event
+	values := [[
+		"http://fhir.nl/fhir/NamingSystem/ura|12345",
+		"http://fhir.nl/fhir/NamingSystem/bsn|123456789",
+	]]
+	patches := log.mask with input as evt(search_params(values))
+	has_redaction(patches, search_identifier_path)
 }
 
 test_keeps_non_bsn_identifier_search_untouched if {
-	event := object.union(base_event, {"input": {"action": {"fhir_rest": {"search_params": {"identifier": [["http://fhir.nl/fhir/NamingSystem/ura|12345"]]}}}}})
-	patches := log.mask with input as event
-	not any_patch_for_path(patches, "/input/action/fhir_rest/search_params/identifier")
+	patches := log.mask with input as evt(search_params([["http://fhir.nl/fhir/NamingSystem/ura|12345"]]))
+	not any_patch_for_path(patches, search_identifier_path)
 }
 
 test_keeps_other_search_params_untouched if {
-	event := object.union(base_event, {"input": {"action": {"fhir_rest": {"search_params": {"_lastUpdated": [["2024-01-01"]]}}}}})
-	patches := log.mask with input as event
-	not any_patch_for_path(patches, "/input/action/fhir_rest/search_params/identifier")
+	other := {"action": {"fhir_rest": {"search_params": {"_lastUpdated": [["2024-01-01"]]}}}}
+	patches := log.mask with input as evt(other)
+	not any_patch_for_path(patches, search_identifier_path)
 }
 
 # --- Wholesale redactions: query, body, header, resource.content ----------
 
 test_redacts_request_query_when_present if {
-	event := object.union(base_event, {"input": {"action": {"request": {"query": "identifier=whatever"}}}})
-	{"op": "upsert", "path": "/input/action/request/query", "value": "[REDACTED]"} in log.mask with input as event
+	patches := log.mask with input as evt({"action": {"request": {"query": "identifier=whatever"}}})
+	has_redaction(patches, "/input/action/request/query")
 }
 
 test_no_query_patch_when_query_empty if {
@@ -95,8 +163,9 @@ test_no_query_patch_when_query_empty if {
 }
 
 test_redacts_request_body_when_present if {
-	event := object.union(base_event, {"input": {"action": {"request": {"body": `{"identifier":[{"system":"http://fhir.nl/fhir/NamingSystem/bsn","value":"123456789"}]}`}}}})
-	{"op": "upsert", "path": "/input/action/request/body", "value": "[REDACTED]"} in log.mask with input as event
+	body := `{"identifier":[{"system":"http://fhir.nl/fhir/NamingSystem/bsn","value":"123456789"}]}`
+	patches := log.mask with input as evt({"action": {"request": {"body": body}}})
+	has_redaction(patches, "/input/action/request/body")
 }
 
 test_no_body_patch_when_body_empty if {
@@ -105,8 +174,9 @@ test_no_body_patch_when_body_empty if {
 }
 
 test_redacts_request_header_when_present if {
-	event := object.union(base_event, {"input": {"action": {"request": {"header": {"Authorization": ["Bearer x"]}}}}})
-	{"op": "upsert", "path": "/input/action/request/header", "value": "[REDACTED]"} in log.mask with input as event
+	header := {"Authorization": ["Bearer x"]}
+	patches := log.mask with input as evt({"action": {"request": {"header": header}}})
+	has_redaction(patches, "/input/action/request/header")
 }
 
 test_no_header_patch_when_header_absent if {
@@ -115,8 +185,12 @@ test_no_header_patch_when_header_absent if {
 }
 
 test_redacts_resource_content_when_present if {
-	event := object.union(base_event, {"input": {"resource": {"content": {"resourceType": "Patient", "identifier": [{"system": "http://fhir.nl/fhir/NamingSystem/bsn", "value": "123456789"}]}}}})
-	{"op": "upsert", "path": "/input/resource/content", "value": "[REDACTED]"} in log.mask with input as event
+	content := {
+		"resourceType": "Patient",
+		"identifier": [{"system": "http://fhir.nl/fhir/NamingSystem/bsn", "value": "123456789"}],
+	}
+	patches := log.mask with input as evt({"resource": {"content": content}})
+	has_redaction(patches, "/input/resource/content")
 }
 
 test_no_content_patch_when_content_absent if {
@@ -135,36 +209,30 @@ test_empty_event_produces_no_patches if {
 # Fail-closed: a non-string value where a string is expected must not raise a
 # type error that causes OPA to fall back to logging the event unmasked.
 test_non_string_enrollment_identifier_does_not_break_mask if {
-	event := object.union(base_event, {"input": {"subject": {"patient_enrollment_identifier": {"unexpected": "shape"}}}})
-	patches := log.mask with input as event
-
-	# The enrollment identifier mask doesn't apply, but other rules still run;
-	# what matters is that evaluation doesn't error.
-	not any_patch_for_path(patches, "/input/subject/patient_enrollment_identifier")
+	patches := log.mask with input as evt(enrollment({"unexpected": "shape"}))
+	not any_patch_for_path(patches, enrollment_path)
 }
 
 test_non_string_search_params_identifier_does_not_break_mask if {
-	event := object.union(base_event, {"input": {"action": {"fhir_rest": {"search_params": {"identifier": [[{"unexpected": "shape"}]]}}}}})
-	patches := log.mask with input as event
-	not any_patch_for_path(patches, "/input/action/fhir_rest/search_params/identifier")
+	patches := log.mask with input as evt(search_params([[{"unexpected": "shape"}]]))
+	not any_patch_for_path(patches, search_identifier_path)
 }
 
 # URN OID is case-insensitive per RFC 8141; a system URI uppercased should
 # still be detected as BSN-scoped.
 test_case_insensitive_oid_match if {
-	event := object.union(base_event, {"input": {"subject": {"patient_enrollment_identifier": "URN:OID:2.16.840.1.113883.2.4.6.3|123456789"}}})
-	{"op": "upsert", "path": "/input/subject/patient_enrollment_identifier", "value": "[REDACTED]"} in log.mask with input as event
+	patches := log.mask with input as evt(enrollment("URN:OID:2.16.840.1.113883.2.4.6.3|123456789"))
+	has_redaction(patches, enrollment_path)
 }
 
 test_case_insensitive_uri_match if {
-	event := object.union(base_event, {"input": {"subject": {"patient_enrollment_identifier": "HTTP://FHIR.NL/FHIR/NAMINGSYSTEM/BSN|123456789"}}})
-	{"op": "upsert", "path": "/input/subject/patient_enrollment_identifier", "value": "[REDACTED]"} in log.mask with input as event
+	patches := log.mask with input as evt(enrollment("HTTP://FHIR.NL/FHIR/NAMINGSYSTEM/BSN|123456789"))
+	has_redaction(patches, enrollment_path)
 }
 
 # Empty header map should not emit a pointless patch.
 test_empty_header_map_produces_no_patch if {
-	event := object.union(base_event, {"input": {"action": {"request": {"header": {}}}}})
-	patches := log.mask with input as event
+	patches := log.mask with input as evt({"action": {"request": {"header": {}}}})
 	not any_patch_for_path(patches, "/input/action/request/header")
 }
 

--- a/component/pdp/policies/system/policy_test.rego
+++ b/component/pdp/policies/system/policy_test.rego
@@ -165,7 +165,7 @@ test_case_insensitive_uri_match if {
 test_empty_header_map_produces_no_patch if {
 	event := object.union(base_event, {"input": {"action": {"request": {"header": {}}}}})
 	patches := log.mask with input as event
-	not "/input/action/request/header" in patches
+	not any_patch_for_path(patches, "/input/action/request/header")
 }
 
 # any_patch_for_path returns true if the mask set contains a patch (either the

--- a/component/pdp/policies/system/policy_test.rego
+++ b/component/pdp/policies/system/policy_test.rego
@@ -1,0 +1,181 @@
+package system.log_test
+
+import rego.v1
+
+import data.system.log
+
+# The mask rule receives the full decision event; the original input sits at
+# `input.input`. These fixtures mirror that structure.
+
+base_event := {
+	"path": "/bgz",
+	"input": {
+		"context": {},
+		"subject": {},
+		"action": {"request": {}, "fhir_rest": {}},
+		"resource": {},
+	},
+}
+
+# --- patient_bsn -----------------------------------------------------------
+
+test_redacts_patient_bsn if {
+	event := object.union(base_event, {"input": {"context": {"patient_bsn": "123456789"}}})
+	{"op": "upsert", "path": "/input/context/patient_bsn", "value": "[REDACTED]"} in log.mask with input as event
+}
+
+test_no_patch_when_patient_bsn_absent if {
+	patches := log.mask with input as base_event
+	not any_patch_for_path(patches, "/input/context/patient_bsn")
+}
+
+test_no_patch_when_patient_bsn_empty if {
+	event := object.union(base_event, {"input": {"context": {"patient_bsn": ""}}})
+	patches := log.mask with input as event
+	not any_patch_for_path(patches, "/input/context/patient_bsn")
+}
+
+# --- patient_enrollment_identifier ----------------------------------------
+
+test_redacts_patient_enrollment_identifier_uri_system if {
+	event := object.union(base_event, {"input": {"subject": {"patient_enrollment_identifier": "http://fhir.nl/fhir/NamingSystem/bsn|123456789"}}})
+	{"op": "upsert", "path": "/input/subject/patient_enrollment_identifier", "value": "[REDACTED]"} in log.mask with input as event
+}
+
+test_redacts_patient_enrollment_identifier_oid_system if {
+	event := object.union(base_event, {"input": {"subject": {"patient_enrollment_identifier": "urn:oid:2.16.840.1.113883.2.4.6.3|123456789"}}})
+	{"op": "upsert", "path": "/input/subject/patient_enrollment_identifier", "value": "[REDACTED]"} in log.mask with input as event
+}
+
+test_keeps_non_bsn_enrollment_identifier_untouched if {
+	event := object.union(base_event, {"input": {"subject": {"patient_enrollment_identifier": "http://fhir.nl/fhir/NamingSystem/ura|12345"}}})
+	patches := log.mask with input as event
+	not any_patch_for_path(patches, "/input/subject/patient_enrollment_identifier")
+}
+
+# --- search_params.identifier ---------------------------------------------
+
+test_redacts_search_params_identifier_uri_system if {
+	event := object.union(base_event, {"input": {"action": {"fhir_rest": {"search_params": {"identifier": [["http://fhir.nl/fhir/NamingSystem/bsn|123456789"]]}}}}})
+	{"op": "upsert", "path": "/input/action/fhir_rest/search_params/identifier", "value": "[REDACTED]"} in log.mask with input as event
+}
+
+test_redacts_search_params_identifier_oid_system if {
+	event := object.union(base_event, {"input": {"action": {"fhir_rest": {"search_params": {"identifier": [["urn:oid:2.16.840.1.113883.2.4.6.3|123456789"]]}}}}})
+	{"op": "upsert", "path": "/input/action/fhir_rest/search_params/identifier", "value": "[REDACTED]"} in log.mask with input as event
+}
+
+test_redacts_identifier_when_bsn_is_second_or_value if {
+	event := object.union(base_event, {"input": {"action": {"fhir_rest": {"search_params": {"identifier": [["http://fhir.nl/fhir/NamingSystem/ura|12345", "http://fhir.nl/fhir/NamingSystem/bsn|123456789"]]}}}}})
+	{"op": "upsert", "path": "/input/action/fhir_rest/search_params/identifier", "value": "[REDACTED]"} in log.mask with input as event
+}
+
+test_keeps_non_bsn_identifier_search_untouched if {
+	event := object.union(base_event, {"input": {"action": {"fhir_rest": {"search_params": {"identifier": [["http://fhir.nl/fhir/NamingSystem/ura|12345"]]}}}}})
+	patches := log.mask with input as event
+	not any_patch_for_path(patches, "/input/action/fhir_rest/search_params/identifier")
+}
+
+test_keeps_other_search_params_untouched if {
+	event := object.union(base_event, {"input": {"action": {"fhir_rest": {"search_params": {"_lastUpdated": [["2024-01-01"]]}}}}})
+	patches := log.mask with input as event
+	not any_patch_for_path(patches, "/input/action/fhir_rest/search_params/identifier")
+}
+
+# --- Wholesale redactions: query, body, header, resource.content ----------
+
+test_redacts_request_query_when_present if {
+	event := object.union(base_event, {"input": {"action": {"request": {"query": "identifier=whatever"}}}})
+	{"op": "upsert", "path": "/input/action/request/query", "value": "[REDACTED]"} in log.mask with input as event
+}
+
+test_no_query_patch_when_query_empty if {
+	patches := log.mask with input as base_event
+	not any_patch_for_path(patches, "/input/action/request/query")
+}
+
+test_redacts_request_body_when_present if {
+	event := object.union(base_event, {"input": {"action": {"request": {"body": `{"identifier":[{"system":"http://fhir.nl/fhir/NamingSystem/bsn","value":"123456789"}]}`}}}})
+	{"op": "upsert", "path": "/input/action/request/body", "value": "[REDACTED]"} in log.mask with input as event
+}
+
+test_no_body_patch_when_body_empty if {
+	patches := log.mask with input as base_event
+	not any_patch_for_path(patches, "/input/action/request/body")
+}
+
+test_redacts_request_header_when_present if {
+	event := object.union(base_event, {"input": {"action": {"request": {"header": {"Authorization": ["Bearer x"]}}}}})
+	{"op": "upsert", "path": "/input/action/request/header", "value": "[REDACTED]"} in log.mask with input as event
+}
+
+test_no_header_patch_when_header_absent if {
+	patches := log.mask with input as base_event
+	not any_patch_for_path(patches, "/input/action/request/header")
+}
+
+test_redacts_resource_content_when_present if {
+	event := object.union(base_event, {"input": {"resource": {"content": {"resourceType": "Patient", "identifier": [{"system": "http://fhir.nl/fhir/NamingSystem/bsn", "value": "123456789"}]}}}})
+	{"op": "upsert", "path": "/input/resource/content", "value": "[REDACTED]"} in log.mask with input as event
+}
+
+test_no_content_patch_when_content_absent if {
+	patches := log.mask with input as base_event
+	not any_patch_for_path(patches, "/input/resource/content")
+}
+
+# --- Edge cases ------------------------------------------------------------
+
+test_empty_event_produces_no_patches if {
+	empty_event := {"path": "/bgz", "input": {}}
+	patches := log.mask with input as empty_event
+	count(patches) == 0
+}
+
+# Fail-closed: a non-string value where a string is expected must not raise a
+# type error that causes OPA to fall back to logging the event unmasked.
+test_non_string_enrollment_identifier_does_not_break_mask if {
+	event := object.union(base_event, {"input": {"subject": {"patient_enrollment_identifier": {"unexpected": "shape"}}}})
+	patches := log.mask with input as event
+
+	# The enrollment identifier mask doesn't apply, but other rules still run;
+	# what matters is that evaluation doesn't error.
+	not any_patch_for_path(patches, "/input/subject/patient_enrollment_identifier")
+}
+
+test_non_string_search_params_identifier_does_not_break_mask if {
+	event := object.union(base_event, {"input": {"action": {"fhir_rest": {"search_params": {"identifier": [[{"unexpected": "shape"}]]}}}}})
+	patches := log.mask with input as event
+	not any_patch_for_path(patches, "/input/action/fhir_rest/search_params/identifier")
+}
+
+# URN OID is case-insensitive per RFC 8141; a system URI uppercased should
+# still be detected as BSN-scoped.
+test_case_insensitive_oid_match if {
+	event := object.union(base_event, {"input": {"subject": {"patient_enrollment_identifier": "URN:OID:2.16.840.1.113883.2.4.6.3|123456789"}}})
+	{"op": "upsert", "path": "/input/subject/patient_enrollment_identifier", "value": "[REDACTED]"} in log.mask with input as event
+}
+
+test_case_insensitive_uri_match if {
+	event := object.union(base_event, {"input": {"subject": {"patient_enrollment_identifier": "HTTP://FHIR.NL/FHIR/NAMINGSYSTEM/BSN|123456789"}}})
+	{"op": "upsert", "path": "/input/subject/patient_enrollment_identifier", "value": "[REDACTED]"} in log.mask with input as event
+}
+
+# Empty header map should not emit a pointless patch.
+test_empty_header_map_produces_no_patch if {
+	event := object.union(base_event, {"input": {"action": {"request": {"header": {}}}}})
+	patches := log.mask with input as event
+	not "/input/action/request/header" in patches
+}
+
+# any_patch_for_path returns true if the mask set contains a patch (either the
+# shorthand string form or an object form) targeting the given path.
+any_patch_for_path(mask_set, path) if {
+	path in mask_set
+}
+
+any_patch_for_path(mask_set, path) if {
+	some patch in mask_set
+	is_object(patch)
+	patch.path == path
+}


### PR DESCRIPTION
Closes #349.

The issue was scoped to OPA decision logs. While investigating I found MITZ XACML debug logs leaked BSNs in the same way, so I expanded the scope to cover both.

**OPA decision logs** (new `data.system.log.mask` rego rule)
- Redacts `context.patient_bsn`, `subject.patient_enrollment_identifier`, and `search_params.identifier` (URI and OID forms of the BSN NamingSystem, case-insensitive)
- Debug-only fields `request.query`, `request.body`, `request.header`, `resource.content` replaced with `[REDACTED]` placeholder so the presence of the field remains visible for triage
- `is_string` guard on mask helpers prevents fail-open on unexpected input shapes
- `system` bundle blocked from being invoked as a policy via scope
- E2E test builds a fully-populated `PolicyInput` struct and asserts the captured slog stream from a real OPA decision contains `[REDACTED]` but not the BSN, with a guard against vacuous pass

**MITZ XACML logs** (found during investigation, same root cause)
- Request, response and error bodies scrubbed via OID-matching regex on the HL7 `InstanceIdentifier`. Catches BSNs echoed back by MITZ that were never sent in the original request, such as those of a legal representative.