### PR TITLE
Fix PEP Authorization to send the request body to subrequest

### DIFF
--- a/component/pdp/fhirreq.go
+++ b/component/pdp/fhirreq.go
@@ -448,7 +448,10 @@ func NewPolicyInput(request APIRequest) (*PolicyInput, error) {
 	}
 
 	var rawParams url.Values
-	hasFormData := request.Input.Request.Header.Get("Content-Type") == "application/x-www-form-urlencoded"
+	contentTypeParts := strings.Split(request.Input.Request.Header.Get("Content-Type"), ";")
+	hasFormData := slices.ContainsFunc(contentTypeParts, func(part string) bool {
+		return strings.TrimSpace(part) == "application/x-www-form-urlencoded"
+	})
 	interWithBody := []fhir.TypeRestfulInteraction{
 		fhir.TypeRestfulInteractionSearchType,
 		fhir.TypeRestfulInteractionOperation,

--- a/pep/nginx/conf.d/knooppunt.conf
+++ b/pep/nginx/conf.d/knooppunt.conf
@@ -50,15 +50,21 @@ server {
     # FHIR_BASE_PATH: incoming path clients use (default: /fhir)
     # FHIR_UPSTREAM_PATH: path on backend FHIR server (default: same as FHIR_BASE_PATH)
     location ${FHIR_BASE_PATH}/ {
-        # Call authorization subrequest before proxying
-        auth_request /_authorize;
+        # Authorize in the main request context (not auth_request subrequest)
+        # so request body is available to njs for PDP input.
+        js_content authorize.authorizeAndProxy;
 
         # Error handling for authorization failures
         error_page 401 = @error401;
         error_page 403 = @error403;
         error_page 500 502 503 504 = @error5xx;
+    }
 
-        # Forward to FHIR backend if authorized
+    # Internal proxy target used after authorize.authorizeAndProxy allows access
+    location @fhir_backend_proxy {
+        internal;
+
+        # Forward to FHIR backend
         rewrite ^${FHIR_BASE_PATH}/(.*)$ ${FHIR_UPSTREAM_PATH}/$1 break;
         proxy_pass http://fhir_backend;
         proxy_set_header Host $host;
@@ -75,12 +81,6 @@ server {
         proxy_connect_timeout 10s;
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
-    }
-
-    # Internal authorization endpoint
-    location = /_authorize {
-        internal;
-        js_content authorize.checkAuthorization;
     }
 
     # Internal: Token introspection via Nuts node (RFC 7662)

--- a/pep/nginx/js/authorize.js
+++ b/pep/nginx/js/authorize.js
@@ -111,6 +111,9 @@ function buildPDPRequest(introspection, request) {
     } else if (requestPath === fhirBasePath) {
         requestPath = '/';
     }
+
+    const contentTypeValue = request.headersIn['Content-Type'] || request.headersIn['content-type'] || '';
+    const contentType = contentTypeValue ? [contentTypeValue] : [''];
     
     return {
         input: {
@@ -120,7 +123,9 @@ function buildPDPRequest(introspection, request) {
                 protocol: 'HTTP/1.1',
                 path: requestPath || '/',
                 query: queryString || '',
-                header: {},
+                header: {
+                    "Content-Type": contentType
+                },
                 body: request.requestText || ''
             },
             context: {
@@ -192,25 +197,23 @@ async function validateDPoP(request, introspection) {
 }
 
 /**
- * Main authorization function called by NGINX auth_request
+ * Main authorization routine used by request handlers
  * @param {Object} request - NGINX request object
  */
-async function checkAuthorization(request) {
+async function authorizeRequest(request) {
     try {
         // Step 1: Extract token from Authorization header
         const token = extractBearerToken(request);
         if (!token) {
             request.error('Missing or invalid Authorization header');
-            request.return(401);
-            return;
+            return { allowed: false, status: 401 };
         }
 
         // RFC 9449: If using DPoP authorization scheme, DPoP header is required
         const tokenType = getTokenType(request);
         if (tokenType === 'dpop' && !request.headersIn['DPoP']) {
             request.error('DPoP authorization scheme requires DPoP header');
-            request.return(401);
-            return;
+            return { allowed: false, status: 401 };
         }
 
         // Step 2: Introspect token via Nuts node (RFC 7662)
@@ -222,14 +225,12 @@ async function checkAuthorization(request) {
             });
         } catch (e) {
             request.error(`Token introspection failed: ${e}`);
-            request.return(502);
-            return;
+            return { allowed: false, status: 502 };
         }
 
         if (introspectionResponse.status !== 200) {
             request.error(`Token introspection returned ${introspectionResponse.status}`);
-            request.return(introspectionResponse.status === 401 ? 401 : 502);
-            return;
+            return { allowed: false, status: introspectionResponse.status === 401 ? 401 : 502 };
         }
 
         let introspection;
@@ -237,14 +238,12 @@ async function checkAuthorization(request) {
             introspection = JSON.parse(introspectionResponse.responseText);
         } catch (e) {
             request.error(`Invalid introspection response: ${e}`);
-            request.return(502);
-            return;
+            return { allowed: false, status: 502 };
         }
 
         if (!introspection.active) {
             request.error('Token is not active');
-            request.return(401);
-            return;
+            return { allowed: false, status: 401 };
         }
 
         request.log(`Token active: client_id=${introspection.client_id}, scope=${introspection.scope}`);
@@ -253,8 +252,7 @@ async function checkAuthorization(request) {
         const dpopResult = await validateDPoP(request, introspection);
         if (!dpopResult.valid) {
             request.error(`DPoP validation failed: ${dpopResult.reason}`);
-            request.return(401);
-            return;
+            return { allowed: false, status: 401 };
         }
 
         // Step 4: Build PDPInput request
@@ -273,14 +271,12 @@ async function checkAuthorization(request) {
             });
         } catch (e) {
             request.error(`PDP unreachable: ${e}`);
-            request.return(502);
-            return;
+            return { allowed: false, status: 502 };
         }
 
         if (pdpResponse.status !== 200) {
             request.error(`PDP returned ${pdpResponse.status}`);
-            request.return(502);
-            return;
+            return { allowed: false, status: 502 };
         }
 
         let pdpResult;
@@ -288,35 +284,51 @@ async function checkAuthorization(request) {
             pdpResult = JSON.parse(pdpResponse.responseText);
         } catch (e) {
             request.error(`Invalid PDP response: ${e}`);
-            request.return(502);
-            return;
+            return { allowed: false, status: 502 };
         }
 
         // Validate PDP response schema
         if (typeof pdpResult.allow !== 'boolean') {
             request.error(`Malformed PDP response: missing allow boolean`);
-            request.return(502);
-            return;
+            return { allowed: false, status: 502 };
         }
 
         // Step 6: Enforce decision
         if (pdpResult.allow === true) {
             request.log('Access ALLOWED by PDP');
-            request.return(200);
+            return { allowed: true, status: 200 };
         } else {
             const reasons = pdpResult.reasons ? pdpResult.reasons : [];
             request.warn(`Access DENIED by PDP: ${JSON.stringify(reasons)}`);
-            request.return(403);
+            return { allowed: false, status: 403 };
         }
 
     } catch (e) {
         request.error(`Authorization error: ${e}`);
-        request.return(500);
+        return { allowed: false, status: 500 };
     }
 }
 
+/**
+ * Authorize current request and proxy to the FHIR backend if allowed.
+ * This runs in the main request context (not auth_request subrequest), so
+ * request.requestText contains the original client body when buffered in memory.
+ * @param {Object} request - NGINX request object
+ */
+async function authorizeAndProxy(request) {
+    const decision = await authorizeRequest(request);
+
+    if (!decision.allowed) {
+        request.return(decision.status);
+        return;
+    }
+
+    request.internalRedirect('@fhir_backend_proxy');
+}
+
 export default {
-    checkAuthorization,
+    authorizeRequest,
+    authorizeAndProxy,
     extractBearerToken,
     getTokenType,
     normalizeClaimValue,

--- a/pep/nginx/js/authorize.test.js
+++ b/pep/nginx/js/authorize.test.js
@@ -203,7 +203,9 @@ describe('buildPDPRequest', () => {
                     protocol: 'HTTP/1.1',
                     path: '/Patient/patient-123', // /fhir/ prefix is stripped
                     query: '_include=Patient:organization',
-                    header: {},
+                    header: {
+                        "Content-Type": ['']
+                    },
                     body: ''
                 },
                 context: {
@@ -415,8 +417,8 @@ describe('validateDPoP', () => {
     });
 });
 
-describe('checkAuthorization integration', () => {
-    const {checkAuthorization} = authorize;
+describe('authorizeRequest integration', () => {
+    const {authorizeRequest} = authorize;
     const originalEnv = process.env;
 
     beforeEach(() => {
@@ -438,9 +440,9 @@ describe('checkAuthorization integration', () => {
     test('returns 401 when no Authorization header', async () => {
         const request = createMockRequest();
 
-        await checkAuthorization(request);
+        const decision = await authorizeRequest(request);
 
-        expect(request.return).toHaveBeenCalledWith(401);
+        expect(decision).toEqual({allowed: false, status: 401});
         expect(request.error).toHaveBeenCalledWith('Missing or invalid Authorization header');
     });
 
@@ -453,9 +455,9 @@ describe('checkAuthorization integration', () => {
             subrequest: mockSubrequest
         });
 
-        await checkAuthorization(request);
+        const decision = await authorizeRequest(request);
 
-        expect(request.return).toHaveBeenCalledWith(401);
+        expect(decision).toEqual({allowed: false, status: 401});
         expect(request.error).toHaveBeenCalledWith('Token is not active');
     });
 
@@ -468,9 +470,9 @@ describe('checkAuthorization integration', () => {
             subrequest: mockSubrequest
         });
 
-        await checkAuthorization(request);
+        const decision = await authorizeRequest(request);
 
-        expect(request.return).toHaveBeenCalledWith(502);
+        expect(decision).toEqual({allowed: false, status: 502});
     });
 
     test('returns 200 when PDP allows', async () => {
@@ -494,9 +496,9 @@ describe('checkAuthorization integration', () => {
             subrequest: mockSubrequest
         });
 
-        await checkAuthorization(request);
+        const decision = await authorizeRequest(request);
 
-        expect(request.return).toHaveBeenCalledWith(200);
+        expect(decision).toEqual({allowed: true, status: 200});
         expect(request.log).toHaveBeenCalledWith('Access ALLOWED by PDP');
     });
 
@@ -527,9 +529,9 @@ describe('checkAuthorization integration', () => {
             subrequest: mockSubrequest
         });
 
-        await checkAuthorization(request);
+        const decision = await authorizeRequest(request);
 
-        expect(request.return).toHaveBeenCalledWith(403);
+        expect(decision).toEqual({allowed: false, status: 403});
         expect(request.warn).toHaveBeenCalled();
     });
 
@@ -553,9 +555,9 @@ describe('checkAuthorization integration', () => {
             subrequest: mockSubrequest
         });
 
-        await checkAuthorization(request);
+        const decision = await authorizeRequest(request);
 
-        expect(request.return).toHaveBeenCalledWith(502);
+        expect(decision).toEqual({allowed: false, status: 502});
         expect(request.error).toHaveBeenCalledWith('Malformed PDP response: missing allow boolean');
     });
 
@@ -585,9 +587,9 @@ describe('checkAuthorization integration', () => {
             subrequest: mockSubrequest
         });
 
-        await checkAuthorization(request);
+        const decision = await authorizeRequest(request);
 
-        expect(request.return).toHaveBeenCalledWith(401);
+        expect(decision).toEqual({allowed: false, status: 401});
         expect(request.error).toHaveBeenCalledWith('DPoP validation failed: invalid signature');
     });
 
@@ -600,9 +602,9 @@ describe('checkAuthorization integration', () => {
             }
         });
 
-        await checkAuthorization(request);
+        const decision = await authorizeRequest(request);
 
-        expect(request.return).toHaveBeenCalledWith(401);
+        expect(decision).toEqual({allowed: false, status: 401});
         expect(request.error).toHaveBeenCalledWith('DPoP authorization scheme requires DPoP header');
     });
 
@@ -633,10 +635,10 @@ describe('checkAuthorization integration', () => {
             subrequest: mockSubrequest
         });
 
-        await checkAuthorization(request);
+        const decision = await authorizeRequest(request);
 
         // Request MUST be blocked - DPoP proof required for tokens with cnf.jkt
-        expect(request.return).toHaveBeenCalledWith(401);
+        expect(decision).toEqual({allowed: false, status: 401});
         expect(request.error).toHaveBeenCalledWith('DPoP validation failed: DPoP header required but missing');
     });
 });


### PR DESCRIPTION
The pull request does the following:
1. Removes `auth_request` subrequest to use the main request context. This is done because `auth_request` doesn't forwards request body. The request body is necessary for POST `/fhir/Patient/_search` requests since the BSN is extracted from the request body.
2. Adds `Content-Type` header in the PDP request since PDP needs it to extract POST requests body.
3. Updated the `Content-Type` check in PDP so that it can handle the values like `application/x-www-form-urlencoded; charset=UTF-8` which HAPI FHIR sends in POST search requests by default.