### PR TITLE
test(pep): e2e for POST _search body + PDP Content-Type refactor

### DIFF
--- a/component/pdp/fhirreq.go
+++ b/component/pdp/fhirreq.go
@@ -451,9 +451,12 @@ func NewPolicyInput(request APIRequest) (*PolicyInput, error) {
 	var rawParams url.Values
 	// Parse Content-Type per RFC 7231 so callers may include parameters
 	// (e.g. "; charset=UTF-8" sent by HAPI FHIR clients). A malformed
-	// header yields an empty mediaType, which correctly falls through
-	// to the query-string branch.
-	mediaType, _, _ := mime.ParseMediaType(request.Input.Request.Header.Get("Content-Type"))
+	// header is treated as non-form and correctly falls through to the
+	// query-string branch.
+	mediaType, _, err := mime.ParseMediaType(request.Input.Request.Header.Get("Content-Type"))
+	if err != nil {
+		mediaType = ""
+	}
 	hasFormData := mediaType == "application/x-www-form-urlencoded"
 	interWithBody := []fhir.TypeRestfulInteraction{
 		fhir.TypeRestfulInteractionSearchType,

--- a/component/pdp/fhirreq.go
+++ b/component/pdp/fhirreq.go
@@ -3,6 +3,7 @@ package pdp
 import (
 	"errors"
 	"fmt"
+	"mime"
 	"net/url"
 	"regexp"
 	"slices"
@@ -448,10 +449,12 @@ func NewPolicyInput(request APIRequest) (*PolicyInput, error) {
 	}
 
 	var rawParams url.Values
-	contentTypeParts := strings.Split(request.Input.Request.Header.Get("Content-Type"), ";")
-	hasFormData := slices.ContainsFunc(contentTypeParts, func(part string) bool {
-		return strings.TrimSpace(part) == "application/x-www-form-urlencoded"
-	})
+	// Parse Content-Type per RFC 7231 so callers may include parameters
+	// (e.g. "; charset=UTF-8" sent by HAPI FHIR clients). A malformed
+	// header yields an empty mediaType, which correctly falls through
+	// to the query-string branch.
+	mediaType, _, _ := mime.ParseMediaType(request.Input.Request.Header.Get("Content-Type"))
+	hasFormData := mediaType == "application/x-www-form-urlencoded"
 	interWithBody := []fhir.TypeRestfulInteraction{
 		fhir.TypeRestfulInteractionSearchType,
 		fhir.TypeRestfulInteractionOperation,

--- a/component/pdp/fhirreq_test.go
+++ b/component/pdp/fhirreq_test.go
@@ -450,6 +450,54 @@ func TestNewPolicyInput(t *testing.T) {
 			assert.Equal(t, "900186021", policyInput.Context.PatientBSN)
 			assert.Empty(t, resultReasons)
 		})
+		t.Run("in POST body, Content-Type variants", func(t *testing.T) {
+			// The PDP is the defensive boundary: it must tolerate RFC 7231-legal
+			// Content-Type variants (parameters, whitespace, case) regardless of
+			// how or whether an individual PEP normalizes the header.
+			cases := []struct {
+				name          string
+				contentType   string
+				expectAsForm  bool
+			}{
+				{"charset parameter with space (HAPI FHIR)", "application/x-www-form-urlencoded; charset=UTF-8", true},
+				{"charset parameter without space", "application/x-www-form-urlencoded;charset=utf-8", true},
+				{"uppercase media type", "APPLICATION/X-WWW-FORM-URLENCODED", true},
+				{"trailing whitespace", "application/x-www-form-urlencoded  ", true},
+				{"multipart/form-data is not form-encoded", "multipart/form-data; boundary=abc", false},
+				{"application/json is not form-encoded", "application/json", false},
+				{"malformed header falls through", "not a valid media type", false},
+			}
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					pdpRequest := APIRequest{
+						Input: APIInput{
+							Request: HTTPRequest{
+								Method:   "POST",
+								Protocol: "HTTP/1.1",
+								Path:     "/Patient/_search",
+								Header: http.Header{
+									"Content-Type": []string{tc.contentType},
+								},
+								Body: "identifier=http://fhir.nl/fhir/NamingSystem/bsn|900186021",
+							},
+							Context: APIContext{
+								ConnectionTypeCode: "hl7-fhir-rest",
+							},
+						},
+					}
+					policyInput, resultReasons := NewPolicyInput(pdpRequest)
+					require.NotNil(t, policyInput)
+					assert.Empty(t, resultReasons)
+					if tc.expectAsForm {
+						assert.Equal(t, "900186021", policyInput.Context.PatientBSN,
+							"body should be parsed as form data for %q", tc.contentType)
+					} else {
+						assert.Empty(t, policyInput.Context.PatientBSN,
+							"body should NOT be parsed as form data for %q", tc.contentType)
+					}
+				})
+			}
+		})
 		t.Run("in POST body, unencoded (pipe character)", func(t *testing.T) {
 			pdpRequest := APIRequest{
 				Input: APIInput{

--- a/test/e2e/pep/authorization_test.go
+++ b/test/e2e/pep/authorization_test.go
@@ -2,7 +2,10 @@ package pep
 
 import (
 	"bytes"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -54,7 +57,7 @@ func Test_PEPAuthorization(t *testing.T) {
 		TestDataDir: testdataDir,
 	})
 
-	createTestPatient(t, pep.HAPIBaseURL)
+	createTestPatient(t, pep.HAPIBaseURL, "patient-123", "900186021")
 
 	subjectName := "requester"
 	subjectDID := createSubject(t, pep.NutsAPI, subjectName)
@@ -186,6 +189,89 @@ func Test_PEPAuthorization(t *testing.T) {
 		defer resp.Body.Close()
 
 		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	// Regression for #492: POST _search with form-encoded body must be authorized
+	// based on parameters in the body (not the empty query string) and the body
+	// must survive nginx's internalRedirect to the FHIR backend. HAPI FHIR clients
+	// send Content-Type with a charset suffix, so that variant is asserted here.
+	//
+	// The HAPI container is reused across go test runs, so the patient/medication
+	// are seeded with per-run unique IDs (same BSN, so the enrollment credential
+	// still matches) and cleaned up in t.Cleanup. Filtering by the unique patient
+	// reference isolates the assertion from any stale data from prior runs.
+	t.Run("authorized POST _search with form-encoded body and charset", func(t *testing.T) {
+		pep.MockMitz.SetResponse("Permit", "Consent granted")
+
+		suffix := randomSuffix(t)
+		patientID := "pep-post-search-patient-" + suffix
+		medID := "pep-post-search-med-" + suffix
+
+		createTestPatient(t, pep.HAPIBaseURL, patientID, "900186021")
+		createTestMedicationRequest(t, pep.HAPIBaseURL, medID, patientID)
+		t.Cleanup(func() {
+			deleteHAPIResource(t, pep.HAPIBaseURL, "MedicationRequest", medID)
+			deleteHAPIResource(t, pep.HAPIBaseURL, "Patient", patientID)
+		})
+
+		form := url.Values{}
+		form.Set("patient", "Patient/"+patientID)
+
+		targetURL := pepBaseURL.JoinPath("fhir", "MedicationRequest", "_search").String()
+		req, err := http.NewRequest("POST", targetURL, strings.NewReader(form.Encode()))
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+bearerToken.AccessToken)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"POST _search must be allowed: PDP needs to see the body-derived patient parameter. Response: %s", string(body))
+		assert.True(t, strings.HasPrefix(resp.Header.Get("Content-Type"), "application/fhir+json"),
+			"Response Content-Type should be FHIR JSON, got %q", resp.Header.Get("Content-Type"))
+
+		var bundle struct {
+			ResourceType string `json:"resourceType"`
+			Entry        []struct {
+				Resource struct {
+					ResourceType string `json:"resourceType"`
+					ID           string `json:"id"`
+				} `json:"resource"`
+			} `json:"entry"`
+		}
+		require.NoError(t, json.Unmarshal(body, &bundle), "response must be a FHIR Bundle: %s", string(body))
+		assert.Equal(t, "Bundle", bundle.ResourceType)
+
+		// Filter is on a per-run unique patient reference. Body preservation through
+		// internalRedirect is the only way HAPI can narrow to exactly this one entry;
+		// an empty or dropped body would yield either an error or an unrelated page.
+		require.Len(t, bundle.Entry, 1, "expected exactly 1 MedicationRequest, got %d: %s", len(bundle.Entry), string(body))
+		assert.Equal(t, "MedicationRequest", bundle.Entry[0].Resource.ResourceType)
+		assert.Equal(t, medID, bundle.Entry[0].Resource.ID)
+	})
+
+	t.Run("denied POST _search when body is empty (no patient derivable)", func(t *testing.T) {
+		// Mitz is irrelevant here: the policy must already deny on missing patient context.
+		// This locks in fail-closed behavior on the body-derived path.
+		pep.MockMitz.SetResponse("Permit", "Consent granted")
+
+		targetURL := pepBaseURL.JoinPath("fhir", "MedicationRequest", "_search").String()
+		req, err := http.NewRequest("POST", targetURL, strings.NewReader(""))
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+bearerToken.AccessToken)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"empty body means no patient context; policy must deny")
 	})
 }
 
@@ -380,23 +466,31 @@ func introspectToken(t *testing.T, nutsAPI func(string) string, token string) ma
 	return result
 }
 
-func createTestPatient(t *testing.T, hapiURL *url.URL) {
+// createTestPatient creates (or replaces) a Patient in HAPI. If bsn is empty,
+// the identifier block is omitted so the helper can also seed a bare patient
+// whose BSN is irrelevant to the test.
+func createTestPatient(t *testing.T, hapiURL *url.URL, id, bsn string) {
 	t.Helper()
 
-	patientJSON := `{
-		"resourceType": "Patient",
-		"id": "patient-123",
+	identifierBlock := ""
+	if bsn != "" {
+		identifierBlock = fmt.Sprintf(`,
 		"identifier": [{
 			"system": "http://fhir.nl/fhir/NamingSystem/bsn",
-			"value": "900186021"
-		}],
+			"value": %q
+		}]`, bsn)
+	}
+
+	patientJSON := fmt.Sprintf(`{
+		"resourceType": "Patient",
+		"id": %q%s,
 		"name": [{
 			"family": "Test",
 			"given": ["Patient"]
 		}]
-	}`
+	}`, id, identifierBlock)
 
-	req, err := http.NewRequest("PUT", hapiURL.JoinPath("DEFAULT", "Patient", "patient-123").String(), strings.NewReader(patientJSON))
+	req, err := http.NewRequest("PUT", hapiURL.JoinPath("DEFAULT", "Patient", id).String(), strings.NewReader(patientJSON))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/fhir+json")
 
@@ -404,4 +498,47 @@ func createTestPatient(t *testing.T, hapiURL *url.URL) {
 	require.NoError(t, err)
 	resp.Body.Close()
 	require.Contains(t, []int{http.StatusOK, http.StatusCreated}, resp.StatusCode)
+}
+
+func createTestMedicationRequest(t *testing.T, hapiURL *url.URL, id, patientID string) {
+	t.Helper()
+
+	medJSON := fmt.Sprintf(`{
+		"resourceType": "MedicationRequest",
+		"id": %q,
+		"status": "active",
+		"intent": "order",
+		"medicationCodeableConcept": {"text": "test medication"},
+		"subject": {"reference": "Patient/%s"}
+	}`, id, patientID)
+
+	req, err := http.NewRequest("PUT", hapiURL.JoinPath("DEFAULT", "MedicationRequest", id).String(), strings.NewReader(medJSON))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/fhir+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Contains(t, []int{http.StatusOK, http.StatusCreated}, resp.StatusCode)
+}
+
+func deleteHAPIResource(t *testing.T, hapiURL *url.URL, resourceType, id string) {
+	t.Helper()
+
+	req, err := http.NewRequest("DELETE", hapiURL.JoinPath("DEFAULT", resourceType, id).String(), nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	// HAPI returns 200 or 204 on success, 404 if already deleted — all acceptable for cleanup.
+	require.Contains(t, []int{http.StatusOK, http.StatusNoContent, http.StatusNotFound}, resp.StatusCode)
+}
+
+func randomSuffix(t *testing.T) string {
+	t.Helper()
+	var b [6]byte
+	_, err := rand.Read(b[:])
+	require.NoError(t, err)
+	return hex.EncodeToString(b[:])
 }


### PR DESCRIPTION
Follow-up to #492. Adds an e2e for `POST /fhir/MedicationRequest/_search` with `form-encoded` body and `Content-Type` carrying a charset parameter. The subtest seeds a `Patient` and `MedicationRequest` with per-run unique IDs (cleaned up in `t.Cleanup`), issues the `POST` through the PEP, and asserts the returned `Bundle` contains exactly the seeded entry. That proves both that the PDP sees the body-derived patient parameter and that the body survives nginx's internalRedirect to the FHIR backend. A fail-closed case for an empty body is included as well.

#492 enabled `POST _search` but the only coverage was njs unit tests with mocked nginx. The real risk lives in the js_content + internalRedirect path, which is only verifiable end-to-end.

The PDP now parses `Content-Type` with `mime.ParseMediaType` instead of a manual split on ';'. A table-driven unit test locks in the tolerated variants (charset with and without space, uppercase, trailing whitespace) plus a negative `multipart/form-data` case. Keeping this logic at the PDP is intentional: the PDP is the stable contract boundary and must accept any RFC 7231-legal header regardless of which PEP (pluggable) sits in front of it.