### PR TITLE
Fix DELETE query parameter encoding for NVI conditional delete

### DIFF
--- a/component/nvi/component.go
+++ b/component/nvi/component.go
@@ -305,7 +305,13 @@ func (c Component) handleDeleteListByParams(httpResponse http.ResponseWriter, ht
 		return
 	}
 
-	err = fhirClient.DeleteWithContext(httpRequest.Context(), "List?"+deleteParams.Encode())
+	var deleteOpts []fhirclient.Option
+	for key, values := range deleteParams {
+		for _, value := range values {
+			deleteOpts = append(deleteOpts, fhirclient.QueryParam(key, value))
+		}
+	}
+	err = fhirClient.DeleteWithContext(httpRequest.Context(), "List", deleteOpts...)
 	if err != nil {
 		err = &fhirapi.Error{
 			Message:   "Failed to delete List at NVI",

--- a/lib/test/fhirclient.go
+++ b/lib/test/fhirclient.go
@@ -455,7 +455,21 @@ func (s *StubFHIRClient) DeleteWithContext(_ context.Context, path string, opts 
 	if s.Error != nil {
 		return s.Error
 	}
-	s.Deletions = append(s.Deletions, path)
+	// Apply opts to a synthetic request so the captured Deletion mirrors the URL
+	// the real client would build (exercising AtPath + QueryParam encoding).
+	request, _ := http.NewRequest("DELETE", "https://example.com/fhir", nil)
+	allOpts := append([]fhirclient.Option{fhirclient.AtPath(path)}, opts...)
+	for _, opt := range allOpts {
+		if pre, ok := opt.(fhirclient.PreRequestOption); ok {
+			pre(s, request)
+		}
+	}
+	relPath := strings.TrimPrefix(request.URL.Path, "/fhir/")
+	relPath = strings.TrimPrefix(relPath, "/fhir")
+	if request.URL.RawQuery != "" {
+		relPath += "?" + request.URL.RawQuery
+	}
+	s.Deletions = append(s.Deletions, relPath)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

`handleDeleteListByParams` constructed the FHIR client call as:

```go
fhirClient.DeleteWithContext(ctx, "List?"+deleteParams.Encode())
```

The fhirclient's `AtPath` option treats the entire string as a single path segment via `url.JoinPath`, which percent-encodes `?` as `%3F`. As a result, the NVI receives:

```
DELETE https://nvi.proeftuin.gf.irealisatie.nl/v1-poc/fhir/List%3Fsource:identifier=...
```

…with the query string baked into the path and no actual query parameters, and rejects with `400 Bad Request`. Discovered against the proeftuin NVI during the GF hackathon.

### Fix
Pass `"List"` as the path and add each parameter via `fhirclient.QueryParam(key, value)`, which sets them on `r.URL.RawQuery` instead.

### Test stub gap
The previous `StubFHIRClient.DeleteWithContext` recorded the raw `path` argument verbatim, so it never exercised the real client's URL construction and could not surface this bug. Updated the stub to apply opts to a synthetic request and capture the resulting relative URL — mirroring what a real FHIR client would send. Existing test expectations remain valid because the resulting URL is identical for correctly-built requests.

## Test plan
- [x] Existing unit tests passing (`component/nvi`)
- [x] Verified end-to-end against the proeftuin NVI: `DELETE /nvi/List?source:identifier=...` now succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)