### PR TITLE
Add a `trusted` flag to mCSD administration directories

### DIFF
--- a/component/mcsd/component.go
+++ b/component/mcsd/component.go
@@ -102,6 +102,7 @@ type administrationDirectory struct {
 	fhirBaseURL      string
 	resourceTypes    []string
 	discover         bool
+	trusted          bool   // Skip validation checks on this directory's contents
 	sourceURL        string // The fullUrl from the Bundle entry that created this Endpoint, used for unregistration on DELETE
 	authoritativeUra string // URA of the organization that is authoritative for this directory
 }
@@ -148,7 +149,7 @@ func New(config Config) (*Component, error) {
 		updateMux:              &sync.RWMutex{},
 	}
 	for _, rootDirectory := range config.AdministrationDirectories {
-		if err := result.registerAdministrationDirectory(context.Background(), rootDirectory.FHIRBaseURL, rootDirectoryResourceTypes, true, "", ""); err != nil {
+		if err := result.registerAdministrationDirectory(context.Background(), rootDirectory.FHIRBaseURL, rootDirectoryResourceTypes, true, "", "", rootDirectory.Trusted); err != nil {
 			return nil, fmt.Errorf("register root administration directory (url=%s): %w", rootDirectory.FHIRBaseURL, err)
 		}
 	}
@@ -181,7 +182,7 @@ func (c *Component) RegisterHttpHandlers(publicMux, internalMux *http.ServeMux) 
 	})
 }
 
-func (c *Component) registerAdministrationDirectory(ctx context.Context, fhirBaseURL string, resourceTypes []string, discover bool, sourceURL string, authoritativeUra string) error {
+func (c *Component) registerAdministrationDirectory(ctx context.Context, fhirBaseURL string, resourceTypes []string, discover bool, sourceURL string, authoritativeUra string, trusted bool) error {
 	// Must be a valid http or https URL
 	parsedFHIRBaseURL, err := url.Parse(fhirBaseURL)
 	if err != nil {
@@ -211,10 +212,11 @@ func (c *Component) registerAdministrationDirectory(ctx context.Context, fhirBas
 		resourceTypes:    resourceTypes,
 		fhirBaseURL:      fhirBaseURL,
 		discover:         discover,
+		trusted:          trusted,
 		sourceURL:        sourceURL,
 		authoritativeUra: authoritativeUra,
 	})
-	slog.InfoContext(ctx, "Registered mCSD Directory", logging.FHIRServer(fhirBaseURL), slog.Bool("discover", discover))
+	slog.InfoContext(ctx, "Registered mCSD Directory", logging.FHIRServer(fhirBaseURL), slog.Bool("discover", discover), slog.Bool("trusted", trusted))
 	return nil
 }
 
@@ -325,7 +327,7 @@ func (c *Component) discoverAndRegisterEndpoints(ctx context.Context, entries []
 			if coding.CodablesIncludesCode(endpoint.PayloadType, payloadCoding) {
 				slog.DebugContext(ctx, "Discovered mCSD Directory", slog.String("address", endpoint.Address))
 
-				err := c.registerAdministrationDirectory(ctx, endpoint.Address, c.directoryResourceTypes, false, fullUrl, authoritativeUra)
+				err := c.registerAdministrationDirectory(ctx, endpoint.Address, c.directoryResourceTypes, false, fullUrl, authoritativeUra, false)
 				if err != nil {
 					report.Warnings = append(report.Warnings, fmt.Sprintf("failed to register discovered mCSD Directory at %s: %s", endpoint.Address, err.Error()))
 				}

--- a/component/mcsd/component.go
+++ b/component/mcsd/component.go
@@ -444,7 +444,7 @@ func (c *Component) updateFromDirectory(ctx context.Context, fhirBaseURLRaw stri
 			continue
 		}
 		slog.DebugContext(ctx, "Processing entry", logging.FHIRServer(fhirBaseURLRaw), slog.String("url", entry.Request.Url))
-		_, err := buildUpdateTransaction(ctx, &tx, entry, ValidationRules{AllowedResourceTypes: allowedResourceTypes}, parentOrganizationsMap, allHealthcareServices, allowDiscovery, fhirBaseURLRaw)
+		_, err := buildUpdateTransaction(ctx, &tx, entry, ValidationRules{AllowedResourceTypes: allowedResourceTypes, Trusted: trusted}, parentOrganizationsMap, allHealthcareServices, allowDiscovery, fhirBaseURLRaw)
 		if err != nil {
 			report.Warnings = append(report.Warnings, fmt.Sprintf("entry #%d: %s", i, err.Error()))
 			continue

--- a/component/mcsd/component.go
+++ b/component/mcsd/component.go
@@ -64,6 +64,11 @@ func makeDirectoryKey(fhirBaseURL, authoritativeUra string) string {
 //   - have the same mcsd-directory-endpoint as the directory being queried
 //   - These are mitigating measures to prevent an attacker to spoof another care organization.
 //   - The organization's mcsd-directory-endpoint must be discoverable through the root mCSD Directory.'
+//
+// A root directory may be marked as 'trusted' (DirectoryConfig.Trusted), which skips the per-resource
+// validation described above. This is intended for directories the operator controls or
+// otherwise trusts (e.g. the LRZA). Trust does not affect sync cadence — incremental sync via _since
+// still applies. Directories discovered from a trusted root are always registered as untrusted.
 type Component struct {
 	config            Config
 	fhirAdminClientFn func(baseURL *url.URL) fhirclient.Client

--- a/component/mcsd/component.go
+++ b/component/mcsd/component.go
@@ -91,6 +91,9 @@ type Config struct {
 
 type DirectoryConfig struct {
 	FHIRBaseURL string `koanf:"fhirbaseurl"`
+	// Trusted disables anti-spoofing validation on this directory's contents.
+	// Only safe for directories you control or otherwise trust (like the LRZA).
+	Trusted bool `koanf:"trusted"`
 }
 
 type UpdateReport map[string]DirectoryUpdateReport

--- a/component/mcsd/component.go
+++ b/component/mcsd/component.go
@@ -255,7 +255,7 @@ func (c *Component) update(ctx context.Context) (UpdateReport, error) {
 	result := make(UpdateReport)
 	for i := 0; i < len(c.administrationDirectories); i++ {
 		adminDirectory := c.administrationDirectories[i]
-		report, err := c.updateFromDirectory(ctx, adminDirectory.fhirBaseURL, adminDirectory.resourceTypes, adminDirectory.discover, adminDirectory.authoritativeUra)
+		report, err := c.updateFromDirectory(ctx, adminDirectory.fhirBaseURL, adminDirectory.resourceTypes, adminDirectory.discover, adminDirectory.authoritativeUra, adminDirectory.trusted)
 		if err != nil {
 			slog.ErrorContext(ctx, "mCSD Directory update failed", logging.FHIRServer(adminDirectory.fhirBaseURL), logging.Error(err))
 			report.Errors = append(report.Errors, err.Error())
@@ -338,8 +338,8 @@ func (c *Component) discoverAndRegisterEndpoints(ctx context.Context, entries []
 	return report
 }
 
-func (c *Component) updateFromDirectory(ctx context.Context, fhirBaseURLRaw string, allowedResourceTypes []string, allowDiscovery bool, authoritativeUra string) (DirectoryUpdateReport, error) {
-	slog.InfoContext(ctx, "Updating from mCSD Directory", logging.FHIRServer(fhirBaseURLRaw), slog.Bool("discover", allowDiscovery), slog.Any("resourceTypes", allowedResourceTypes))
+func (c *Component) updateFromDirectory(ctx context.Context, fhirBaseURLRaw string, allowedResourceTypes []string, allowDiscovery bool, authoritativeUra string, trusted bool) (DirectoryUpdateReport, error) {
+	slog.InfoContext(ctx, "Updating from mCSD Directory", logging.FHIRServer(fhirBaseURLRaw), slog.Bool("discover", allowDiscovery), slog.Bool("trusted", trusted), slog.Any("resourceTypes", allowedResourceTypes))
 	remoteAdminDirectoryFHIRBaseURL, err := url.Parse(fhirBaseURLRaw)
 	if err != nil {
 		return DirectoryUpdateReport{}, err
@@ -371,16 +371,20 @@ func (c *Component) updateFromDirectory(ctx context.Context, fhirBaseURLRaw stri
 		return DirectoryUpdateReport{}, err
 	}
 
-	// Check if any Organization's URA identifier has changed between history versions
-	uraIdentifierChanged := checkForURAIdentifierChanges(entries)
-	if uraIdentifierChanged {
-		slog.WarnContext(ctx, "Detected URA identifier change in organization history. Rerunning history query without _since parameter.", logging.FHIRServer(fhirBaseURLRaw))
+	// Check if any Organization's URA identifier has changed between history versions.
+	// Skipped for trusted directories: a URA change is synced like any other change,
+	// since we don't validate against URA identifiers in trusted mode.
+	if !trusted {
+		uraIdentifierChanged := checkForURAIdentifierChanges(entries)
+		if uraIdentifierChanged {
+			slog.WarnContext(ctx, "Detected URA identifier change in organization history. Rerunning history query without _since parameter.", logging.FHIRServer(fhirBaseURLRaw))
 
-		// Remove _since parameter and rerun the query
-		searchParams.Del("_since")
-		entries, firstSearchSet, err = c.queryAllResourceTypes(ctx, remoteAdminDirectoryFHIRClient, allowedResourceTypes, searchParams)
-		if err != nil {
-			return DirectoryUpdateReport{}, err
+			// Remove _since parameter and rerun the query
+			searchParams.Del("_since")
+			entries, firstSearchSet, err = c.queryAllResourceTypes(ctx, remoteAdminDirectoryFHIRClient, allowedResourceTypes, searchParams)
+			if err != nil {
+				return DirectoryUpdateReport{}, err
+			}
 		}
 	}
 
@@ -406,17 +410,24 @@ func (c *Component) updateFromDirectory(ctx context.Context, fhirBaseURLRaw stri
 		c.processEndpointDeletes(ctx, deduplicatedEntries)
 	}
 
-	// Find parent organizations with URA identifier and all organizations linked to them
-	// This is used when validating organizations that don't have their own URA identifier
-	parentOrganizationsMap, err := c.ensureParentOrganizationsMap(ctx, fhirBaseURLRaw, remoteAdminDirectoryFHIRClient, authoritativeUra)
-
-	if err != nil {
-		return DirectoryUpdateReport{}, fmt.Errorf("failed to build parent organization map: %w", err)
+	// Find parent organizations with URA identifier and all organizations linked to them.
+	// Used both for validating organizations that don't have their own URA identifier and
+	// for endpoint discovery. For trusted directories without discovery, neither applies
+	// so the map stays nil.
+	var parentOrganizationsMap parentOrganizationMap
+	if !trusted || allowDiscovery {
+		parentOrganizationsMap, err = c.ensureParentOrganizationsMap(ctx, fhirBaseURLRaw, remoteAdminDirectoryFHIRClient, authoritativeUra)
+		if err != nil {
+			return DirectoryUpdateReport{}, fmt.Errorf("failed to build parent organization map: %w", err)
+		}
 	}
 
-	// Validate all parent organizations once before processing resources
-	if err := ValidateParentOrganizations(parentOrganizationsMap); err != nil {
-		return DirectoryUpdateReport{}, fmt.Errorf("parent organization (one that supposedly has ura identifier - and only only) validation failed: %w", err)
+	// Validate all parent organizations once before processing resources.
+	// Skipped for trusted directories.
+	if !trusted {
+		if err := ValidateParentOrganizations(parentOrganizationsMap); err != nil {
+			return DirectoryUpdateReport{}, fmt.Errorf("parent organization (one that supposedly has ura identifier - and only only) validation failed: %w", err)
+		}
 	}
 
 	// Build transaction with deterministic conditional references

--- a/component/mcsd/component_test.go
+++ b/component/mcsd/component_test.go
@@ -795,7 +795,7 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 		})
 		component, err := New(DefaultConfig())
 		require.NoError(t, err)
-		report, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization"}, false, "")
+		report, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization"}, false, "", false)
 		require.NoError(t, err)
 		require.NotNil(t, report)
 		require.Len(t, report.Warnings, 1)
@@ -834,7 +834,7 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 			return &test.StubFHIRClient{Error: errors.New("unknown URL")}
 		}
 
-		report, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization", "Endpoint"}, false, "")
+		report, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization", "Endpoint"}, false, "", false)
 
 		require.NoError(t, err)
 		require.Empty(t, report.Errors, "Should not have errors after deduplication")
@@ -993,7 +993,7 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 		}
 
 		// First update - should discover and register the Endpoint
-		report1, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Endpoint", "Organization"}, true, "")
+		report1, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Endpoint", "Organization"}, true, "", false)
 		require.NoError(t, err)
 		require.Empty(t, report1.Errors)
 		require.Equal(t, 1, report1.CountCreated, "Should have created 1 Endpoint")
@@ -1017,7 +1017,7 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 		assert.Equal(t, "http://test.example.org/fhir/Endpoint/test-endpoint", registeredFullUrl, "Registered Endpoint should have fullUrl from Bundle entry")
 
 		// Second update - should process DELETE and unregister the Endpoint
-		report2, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Endpoint", "Organization"}, true, "")
+		report2, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Endpoint", "Organization"}, true, "", false)
 		require.NoError(t, err)
 		require.Empty(t, report2.Errors)
 
@@ -1101,7 +1101,7 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 
 		// Call updateFromDirectory with only Organization and Endpoint
 		allowedTypes := []string{"Organization", "Endpoint"}
-		report, err := component.updateFromDirectory(ctx, server.URL+"/fhir", allowedTypes, false, "")
+		report, err := component.updateFromDirectory(ctx, server.URL+"/fhir", allowedTypes, false, "", false)
 
 		require.NoError(t, err)
 		require.Empty(t, report.Errors)
@@ -1269,7 +1269,7 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 		}
 
 		// Register the root directory (which will query using rootDirectoryResourceTypes: Organization, Endpoint)
-		err = component.registerAdministrationDirectory(ctx, server.URL+"/fhir", rootDirectoryResourceTypes, true, "", "")
+		err = component.registerAdministrationDirectory(ctx, server.URL+"/fhir", rootDirectoryResourceTypes, true, "", "", false)
 		require.NoError(t, err)
 
 		// First update should discover the endpoint from root directory and immediately query it
@@ -1346,7 +1346,7 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		component, err := New(config)
 		require.NoError(t, err)
 
-		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir", []string{"Organization"}, false, "", "")
+		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir", []string{"Organization"}, false, "", "", false)
 
 		require.NoError(t, err, "Should not error when URL is excluded, just skip registration")
 		assert.Len(t, component.administrationDirectories, 0, "No directories should be registered")
@@ -1361,7 +1361,7 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to register with trailing slash - should still be excluded
-		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir/", []string{"Organization"}, false, "", "")
+		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir/", []string{"Organization"}, false, "", "", false)
 
 		require.NoError(t, err, "Should not error when URL is excluded, just skip registration")
 		assert.Len(t, component.administrationDirectories, 0, "No directories should be registered")
@@ -1376,7 +1376,7 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to register without trailing slash - should still be excluded due to trimming
-		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir", []string{"Organization"}, false, "", "")
+		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir", []string{"Organization"}, false, "", "", false)
 
 		require.NoError(t, err, "Should not error when URL is excluded, just skip registration")
 		assert.Len(t, component.administrationDirectories, 0, "No directories should be registered")
@@ -1390,7 +1390,7 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		component, err := New(config)
 		require.NoError(t, err)
 
-		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir/", []string{"Organization"}, false, "", "")
+		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir/", []string{"Organization"}, false, "", "", false)
 
 		require.NoError(t, err, "Should not error when URL is excluded, just skip registration")
 		assert.Len(t, component.administrationDirectories, 0, "No directories should be registered")
@@ -1404,7 +1404,7 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		component, err := New(config)
 		require.NoError(t, err)
 
-		err = component.registerAdministrationDirectory(context.Background(), "http://allowed.com/fhir", []string{"Organization"}, false, "", "")
+		err = component.registerAdministrationDirectory(context.Background(), "http://allowed.com/fhir", []string{"Organization"}, false, "", "", false)
 
 		require.NoError(t, err)
 		assert.Len(t, component.administrationDirectories, 1, "Directory should be registered")
@@ -1424,7 +1424,7 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to register the same URL as admin directory - should be excluded
-		err = component.registerAdministrationDirectory(context.Background(), ownFHIRBaseURL, []string{"Organization"}, true, "", "")
+		err = component.registerAdministrationDirectory(context.Background(), ownFHIRBaseURL, []string{"Organization"}, true, "", "", false)
 
 		require.NoError(t, err, "Should not error when URL is excluded, just skip registration")
 		assert.Len(t, component.administrationDirectories, 0, "Own directory should not be registered as admin directory")
@@ -1441,12 +1441,12 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to register excluded directories
-		err1 := component.registerAdministrationDirectory(context.Background(), "http://excluded1.com/fhir", []string{"Organization"}, false, "", "")
-		err2 := component.registerAdministrationDirectory(context.Background(), "http://excluded2.com/fhir", []string{"Organization"}, false, "", "")
-		err3 := component.registerAdministrationDirectory(context.Background(), "http://excluded3.com/fhir", []string{"Organization"}, false, "", "")
+		err1 := component.registerAdministrationDirectory(context.Background(), "http://excluded1.com/fhir", []string{"Organization"}, false, "", "", false)
+		err2 := component.registerAdministrationDirectory(context.Background(), "http://excluded2.com/fhir", []string{"Organization"}, false, "", "", false)
+		err3 := component.registerAdministrationDirectory(context.Background(), "http://excluded3.com/fhir", []string{"Organization"}, false, "", "", false)
 
 		// Register an allowed directory
-		err4 := component.registerAdministrationDirectory(context.Background(), "http://allowed.com/fhir", []string{"Organization"}, false, "", "")
+		err4 := component.registerAdministrationDirectory(context.Background(), "http://allowed.com/fhir", []string{"Organization"}, false, "", "", false)
 
 		require.NoError(t, err1, "Should not error when URL is excluded, just skip registration")
 		require.NoError(t, err2, "Should not error when URL is excluded, just skip registration")
@@ -1461,7 +1461,7 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		component, err := New(config)
 		require.NoError(t, err)
 
-		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir", []string{"Organization"}, false, "", "")
+		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir", []string{"Organization"}, false, "", "", false)
 
 		require.NoError(t, err)
 		assert.Len(t, component.administrationDirectories, 1, "Directory should be registered when exclusion list is empty")
@@ -1476,7 +1476,7 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		require.NoError(t, err)
 
 		// Invalid URL should return error, not silently skip
-		err = component.registerAdministrationDirectory(context.Background(), "not-a-valid-url", []string{"Organization"}, false, "", "")
+		err = component.registerAdministrationDirectory(context.Background(), "not-a-valid-url", []string{"Organization"}, false, "", "", false)
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid FHIR base URL")

--- a/component/mcsd/component_test.go
+++ b/component/mcsd/component_test.go
@@ -1312,6 +1312,152 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 	})
 }
 
+func TestComponent_updateFromDirectory_trusted(t *testing.T) {
+	ctx := context.Background()
+
+	emptyHistoryBundle := `{"resourceType": "Bundle", "type": "history", "entry": []}`
+	emptySearchsetBundle := `{"resourceType": "Bundle", "type": "searchset", "entry": []}`
+
+	makeComponent := func(t *testing.T, server *httptest.Server) (*Component, *test.StubFHIRClient) {
+		capturingClient := &test.StubFHIRClient{}
+		config := DefaultConfig()
+		config.QueryDirectory = DirectoryConfig{FHIRBaseURL: "http://example.com/local/fhir"}
+		component, err := New(config)
+		require.NoError(t, err)
+		component.fhirQueryClient = capturingClient
+		component.fhirAdminClientFn = func(baseURL *url.URL) fhirclient.Client {
+			if baseURL.String() == server.URL+"/fhir" {
+				return fhirclient.New(baseURL, http.DefaultClient, &fhirclient.Config{UsePostSearch: false})
+			}
+			return capturingClient
+		}
+		return component, capturingClient
+	}
+
+	t.Run("bypasses per-resource validation when trusted", func(t *testing.T) {
+		// Organization with no URA identifier and no partOf reference.
+		// Untrusted validation rejects this; trusted accepts it.
+		spoofedOrgHistoryBundle := `{
+			"resourceType": "Bundle",
+			"type": "history",
+			"entry": [{
+				"fullUrl": "http://remote.example.org/fhir/Organization/spoofed",
+				"resource": {
+					"resourceType": "Organization",
+					"id": "spoofed",
+					"name": "Spoofed Org",
+					"active": true
+				},
+				"request": {"method": "POST", "url": "Organization/spoofed"}
+			}]
+		}`
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/fhir/Organization/_history", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(spoofedOrgHistoryBundle))
+		})
+		mux.HandleFunc("/fhir/Organization", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(emptySearchsetBundle))
+		})
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		// Untrusted: spoofed Organization rejected, no resources synced.
+		c1, client1 := makeComponent(t, server)
+		report, err := c1.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization"}, false, "", false)
+		require.NoError(t, err)
+		assert.Empty(t, report.Errors)
+		require.Len(t, report.Warnings, 1, "untrusted should reject spoofed Organization")
+		assert.Empty(t, client1.CreatedResources["Organization"])
+		assert.Equal(t, 0, report.CountCreated)
+
+		// Trusted: spoofed Organization accepted and synced.
+		c2, client2 := makeComponent(t, server)
+		report, err = c2.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization"}, false, "", true)
+		require.NoError(t, err)
+		assert.Empty(t, report.Errors)
+		assert.Empty(t, report.Warnings, "trusted should accept spoofed Organization")
+		assert.Len(t, client2.CreatedResources["Organization"], 1)
+		assert.Equal(t, 1, report.CountCreated)
+	})
+
+	t.Run("skips parent organization query when trusted and not discovering", func(t *testing.T) {
+		var orgQueryCount int
+		var mu sync.Mutex
+		mux := http.NewServeMux()
+		mux.HandleFunc("/fhir/Organization/_history", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(emptyHistoryBundle))
+		})
+		mux.HandleFunc("/fhir/Organization", func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			orgQueryCount++
+			mu.Unlock()
+			_, _ = w.Write([]byte(emptySearchsetBundle))
+		})
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		c, _ := makeComponent(t, server)
+		_, err := c.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization"}, false, "", true)
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Equal(t, 0, orgQueryCount, "trusted+!discover should not query parent organizations")
+	})
+
+	t.Run("still uses _since for incremental sync when trusted", func(t *testing.T) {
+		// _since is stripped for Organization queries (see queryAllResourceTypes),
+		// so use Endpoint to verify incremental sync.
+		validEndpointHistoryBundle := `{
+			"resourceType": "Bundle",
+			"type": "history",
+			"meta": {"lastUpdated": "2025-01-01T00:00:00Z"},
+			"entry": [{
+				"fullUrl": "http://remote.example.org/fhir/Endpoint/ep1",
+				"resource": {
+					"resourceType": "Endpoint",
+					"id": "ep1",
+					"status": "active",
+					"address": "https://example.com/fhir",
+					"connectionType": {
+						"system": "http://terminology.hl7.org/CodeSystem/endpoint-connection-type",
+						"code": "hl7-fhir-rest"
+					},
+					"payloadType": [{
+						"coding": [{"system": "x", "code": "y"}]
+					}]
+				},
+				"request": {"method": "POST", "url": "Endpoint/ep1"}
+			}]
+		}`
+
+		var sinceParams []string
+		var mu sync.Mutex
+		mux := http.NewServeMux()
+		mux.HandleFunc("/fhir/Endpoint/_history", func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			sinceParams = append(sinceParams, r.URL.Query().Get("_since"))
+			mu.Unlock()
+			_, _ = w.Write([]byte(validEndpointHistoryBundle))
+		})
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		c, _ := makeComponent(t, server)
+		_, err := c.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Endpoint"}, false, "", true)
+		require.NoError(t, err)
+		_, err = c.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Endpoint"}, false, "", true)
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Len(t, sinceParams, 2)
+		assert.Empty(t, sinceParams[0], "first update should not include _since")
+		assert.NotEmpty(t, sinceParams[1], "second update should include _since (trusted does not affect sync cadence)")
+	})
+}
+
 func startMockServer(t *testing.T, filesToServe map[string]string) *httptest.Server {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)

--- a/component/mcsd/validator.go
+++ b/component/mcsd/validator.go
@@ -16,6 +16,8 @@ import (
 type ValidationRules struct {
 	// AllowedResourceTypes is a list of FHIR resource types that are allowed to be created/updated.
 	AllowedResourceTypes []string
+	// Trusted skips per-resource spoofing validation. AllowedResourceTypes is still enforced.
+	Trusted bool
 }
 
 // ValidateParentOrganizations validates all parent organizations in the map.
@@ -43,6 +45,11 @@ func ValidateUpdate(ctx context.Context, rules ValidationRules, resourceJSON []b
 	// Base validation
 	if !slices.Contains(rules.AllowedResourceTypes, resourceType) {
 		return fmt.Errorf("resource type %s not allowed", resourceType)
+	}
+
+	// Trusted directories bypass per-resource validation.
+	if rules.Trusted {
+		return nil
 	}
 
 	switch resourceType {

--- a/config/knooppunt.yml
+++ b/config/knooppunt.yml
@@ -9,6 +9,13 @@ mcsd:
   query:
     fhirbaseurl: "http://localhost:8080/fhir"
 
+  # Administration directories to sync from.
+  # Set `trusted: true` to skip anti-spoofing validation on a directory's contents.
+  # admin:
+  #   example:
+  #     fhirbaseurl: "https://fhir.example.org/fhir"
+  #     trusted: true
+
   # Exclude administration directories from being registered
   # Use this to prevent your own FHIR server from being added as an admin directory
   # This avoids syncing your own resources back to yourself


### PR DESCRIPTION
 ## Summary                                                                                
                                                                                            
  Add a `trusted` flag to mCSD administration directories. A trusted directory's contents   
  are accepted without per-resource validation, intended for directories the  
  operator controls or otherwise trusts (e.g. the LRZA).                                    
                                                                                          
  Configured per directory via `mcsd.admin.<name>.trusted: true`. Defaults to `false`, so   
  existing deployments are unaffected.                                                      
                                                                                            
  ## Behavior                                                                               

  When `trusted: true` on a registered directory:

  - `ValidateUpdate` short-circuits after the `AllowedResourceTypes` check — per-resource   
  spoofing checks (URA membership, partOf chain, endpoint reference, etc.) are skipped.
  - `ValidateParentOrganizations` is skipped.                                               
  - The parent-organization map is only built when discovery is also enabled (it's the only 
  remaining consumer in trusted mode).                                                      
  - The URA-identifier-change re-query is skipped — a URA change syncs like any other change
   rather than triggering a full re-fetch.                                                  
                                                   
  Explicitly **unchanged** by `trusted`:                                                    
                                                   
  - Sync cadence: incremental sync via `_since` and `lastUpdateTimes` still applies.        
  - Discovery: a trusted root with `discover: true` still discovers and registers leaf
  directories. Discovered children are always registered as `trusted: false`.               
  - The `isDiscoverableDirectory` filter (root directories only sync mCSD-directory
  `Endpoint` resources) is unchanged.                                                       
  - `AllowedResourceTypes` is still enforced.