### PR TITLE
Handle delegated requests in Mitz consent check

### DIFF
--- a/component/mitz/xacml/types.go
+++ b/component/mitz/xacml/types.go
@@ -79,7 +79,7 @@ type AuthzRequest struct {
 	// Example: "000095254" (UZI number)
 	ProviderID string
 
-	// MandatedID UZI number of practitioner who delegated
+	// MandatedID is the UZI number of the practitioner acting under the mandate (delegated-to)
 	// Example: "000095254" (UZI number)
 	MandatedID *string
 

--- a/component/mitz/xacml/types.go
+++ b/component/mitz/xacml/types.go
@@ -79,6 +79,10 @@ type AuthzRequest struct {
 	// Example: "000095254" (UZI number)
 	ProviderID string
 
+	// MandatedID UZI number of practitioner who delegated
+	// Example: "000095254" (UZI number)
+	MandatedID *string
+
 	// ProviderInstitutionID is the unique identifier (URA code) of the healthcare institution (consulting organization)
 	// REQUIRED - Identifies the consulting/responsible organization.
 	// Example: "00000666" (institution URA code)

--- a/component/mitz/xacml/xacml.go
+++ b/component/mitz/xacml/xacml.go
@@ -113,6 +113,15 @@ func createAuthzDecisionQuery(req AuthzRequest, signingConfig *SigningConfig) (s
 		req.SubjectRole,
 		"2.16.840.1.113883.2.4.15.111")
 
+	if req.MandatedID != nil {
+		// Mandated Identifier
+		addHL7InstanceIdentifierAttributeWithAssigningAuthority(subjectAttrs,
+			"urn:nl:otv:names:tc:1.0:subject:mandated",
+			"2.16.528.1.1007.3.1",
+			*req.MandatedID,
+			"CIBG")
+	}
+
 	// Provider Identifier
 	addHL7InstanceIdentifierAttributeWithAssigningAuthority(subjectAttrs,
 		"urn:ihe:iti:xua:2017:subject:provider-identifier",

--- a/component/pdp/mitz.go
+++ b/component/pdp/mitz.go
@@ -60,7 +60,7 @@ func xacmlFromInput(input PolicyInput) (xacml.AuthzRequest, error) {
 		// If the request is mandated, the practitioner who mandated is responsible
 		s, _ := delRegByProp.(string)
 		iden, err := fhirutil.TokenToIdentifier(s)
-		if err != nil && iden.Value != nil {
+		if err == nil && iden.Value != nil {
 			responsiblePractitioner = *iden.Value
 		} else {
 			return xacml.AuthzRequest{}, errors.New("invalid format for delegation_registered_by")
@@ -69,7 +69,7 @@ func xacmlFromInput(input PolicyInput) (xacml.AuthzRequest, error) {
 		if hasDelegatedRole {
 			s, _ = delRoleProp.(string)
 			iden, err = fhirutil.TokenToIdentifier(s)
-			if err != nil && iden.Value != nil {
+			if err == nil && iden.Value != nil {
 				responsiblePractitionerRole = *iden.Value
 			} else {
 				return xacml.AuthzRequest{}, errors.New("missing delegation_role_code")

--- a/component/pdp/mitz.go
+++ b/component/pdp/mitz.go
@@ -2,6 +2,7 @@ package pdp
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/nuts-foundation/nuts-knooppunt/component/mitz/xacml"
@@ -26,7 +27,16 @@ func (c *Component) enrichPolicyInputWithMitz(ctx context.Context, input *Policy
 		return input, resultReasons
 	}
 
-	consentReq := xacmlFromInput(*input)
+	consentReq, err := xacmlFromInput(*input)
+	if err != nil {
+		slog.WarnContext(ctx, "Mitz consent check failed", "error", err)
+		return input, []ResultReason{
+			{
+				Code:        TypeResultCodeUnexpectedInput,
+				Description: "could not complete consent check with Mitz: " + err.Error(),
+			},
+		}
+	}
 	consentResp, err := c.consentChecker.CheckConsent(ctx, consentReq)
 	if err != nil {
 		slog.WarnContext(ctx, "Mitz consent check failed", "error", err)
@@ -41,19 +51,39 @@ func (c *Component) enrichPolicyInputWithMitz(ctx context.Context, input *Policy
 	return input, nil
 }
 
-func xacmlFromInput(input PolicyInput) xacml.AuthzRequest {
+func xacmlFromInput(input PolicyInput) (xacml.AuthzRequest, error) {
 	delRegByProp, isDelegated := input.Subject.OtherProps["delegation_registered_by"]
+	delRoleProp, hasDelegatedRole := input.Subject.OtherProps["delegation_role_code"]
 	var responsiblePractitioner string
+	var responsiblePractitionerRole string
 	if isDelegated {
 		// If the request is mandated, the practitioner who mandated is responsible
 		s, _ := delRegByProp.(string)
 		iden, err := fhirutil.TokenToIdentifier(s)
 		if err != nil && iden.Value != nil {
 			responsiblePractitioner = *iden.Value
+		} else {
+			return xacml.AuthzRequest{}, errors.New("invalid format for delegation_registered_by")
 		}
+
+		if hasDelegatedRole {
+			s, _ = delRoleProp.(string)
+			iden, err = fhirutil.TokenToIdentifier(s)
+			if err != nil && iden.Value != nil {
+				responsiblePractitionerRole = *iden.Value
+			} else {
+				return xacml.AuthzRequest{}, errors.New("missing delegation_role_code")
+			}
+		} else {
+			// Subject role is a mandatory field is Mitz
+			// If the responsibility is delegated but there is no role, we can only error out
+			return xacml.AuthzRequest{}, errors.New("missing delegation_role_code")
+		}
+
 	} else {
 		// If the request is not mandated the (Dezi) authenticated practitioner is responsible
 		responsiblePractitioner = input.Subject.User.Id
+		responsiblePractitionerRole = input.Subject.User.Role
 	}
 
 	req := xacml.AuthzRequest{
@@ -62,7 +92,7 @@ func xacmlFromInput(input PolicyInput) xacml.AuthzRequest {
 		AuthorInstitutionID:    input.Context.DataHolderOrganizationId,
 		// This code is always the same, it's the code for _de gesloten vraag_
 		EventCode:              "GGC002",
-		SubjectRole:            input.Subject.User.Role,
+		SubjectRole:            responsiblePractitionerRole,
 		ProviderID:             responsiblePractitioner,
 		ProviderInstitutionID:  input.Subject.Organization.Ura,
 		ConsultingFacilityType: input.Subject.Organization.FacilityType,
@@ -73,7 +103,7 @@ func xacmlFromInput(input PolicyInput) xacml.AuthzRequest {
 		// If the request is mandated add the practitioner that has been delegated to
 		req.MandatedID = to.Ptr(input.Subject.User.Id)
 	}
-	return req
+	return req, nil
 }
 
 func validateMitzInput(input PolicyInput) []ResultReason {

--- a/component/pdp/mitz.go
+++ b/component/pdp/mitz.go
@@ -72,7 +72,7 @@ func xacmlFromInput(input PolicyInput) (xacml.AuthzRequest, error) {
 			if err == nil && iden.Value != nil {
 				responsiblePractitionerRole = *iden.Value
 			} else {
-				return xacml.AuthzRequest{}, errors.New("missing delegation_role_code")
+				return xacml.AuthzRequest{}, errors.New("malformed delegation_role_code")
 			}
 		} else {
 			// Subject role is a mandatory field is Mitz

--- a/component/pdp/mitz.go
+++ b/component/pdp/mitz.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/nuts-foundation/nuts-knooppunt/component/mitz/xacml"
 	"github.com/nuts-foundation/nuts-knooppunt/lib/fhirutil"
-	"github.com/zorgbijjou/golang-fhir-models/fhir-models/caramel/to"
 )
 
 func (c *Component) enrichPolicyInputWithMitz(ctx context.Context, input *PolicyInput) (*PolicyInput, []ResultReason) {
@@ -104,8 +103,8 @@ func xacmlFromInput(input PolicyInput) (xacml.AuthzRequest, error) {
 	}
 
 	if isDelegated {
-		// If the request is mandated add the practitioner that has been delegated to
-		req.MandatedID = to.Ptr(input.Subject.User.Id)
+		// If the request is mandated, add the practitioner that has been delegated to,
+		req.MandatedID = new(input.Subject.User.Id)
 	}
 	return req, nil
 }

--- a/component/pdp/mitz.go
+++ b/component/pdp/mitz.go
@@ -53,7 +53,7 @@ func (c *Component) enrichPolicyInputWithMitz(ctx context.Context, input *Policy
 func xacmlFromInput(input PolicyInput) (xacml.AuthzRequest, error) {
 	delRegByProp, isDelegated := input.Subject.OtherProps["delegation_registered_by"]
 	delRoleProp, hasDelegatedRole := input.Subject.OtherProps["delegation_role_code"]
-	if isDelegated && !hasDelegatedRole {
+	if !isDelegated && hasDelegatedRole {
 		return xacml.AuthzRequest{}, errors.New("inconsistent credentials, delegation_role_code without a delegation_registered_by present")
 	}
 

--- a/component/pdp/mitz.go
+++ b/component/pdp/mitz.go
@@ -54,6 +54,10 @@ func (c *Component) enrichPolicyInputWithMitz(ctx context.Context, input *Policy
 func xacmlFromInput(input PolicyInput) (xacml.AuthzRequest, error) {
 	delRegByProp, isDelegated := input.Subject.OtherProps["delegation_registered_by"]
 	delRoleProp, hasDelegatedRole := input.Subject.OtherProps["delegation_role_code"]
+	if isDelegated && !hasDelegatedRole {
+		return xacml.AuthzRequest{}, errors.New("inconsistent credentials, delegation_role_code without a delegation_registered_by present")
+	}
+
 	var responsiblePractitioner string
 	var responsiblePractitionerRole string
 	if isDelegated {

--- a/component/pdp/mitz.go
+++ b/component/pdp/mitz.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 
 	"github.com/nuts-foundation/nuts-knooppunt/component/mitz/xacml"
+	"github.com/nuts-foundation/nuts-knooppunt/lib/fhirutil"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/caramel/to"
 )
 
 func (c *Component) enrichPolicyInputWithMitz(ctx context.Context, input *PolicyInput) (*PolicyInput, []ResultReason) {
@@ -40,18 +42,38 @@ func (c *Component) enrichPolicyInputWithMitz(ctx context.Context, input *Policy
 }
 
 func xacmlFromInput(input PolicyInput) xacml.AuthzRequest {
-	return xacml.AuthzRequest{
+	delRegByProp, isDelegated := input.Subject.OtherProps["delegation_registered_by"]
+	var responsiblePractitioner string
+	if isDelegated {
+		// If the request is mandated, the practitioner who mandated is responsible
+		s, _ := delRegByProp.(string)
+		iden, err := fhirutil.TokenToIdentifier(s)
+		if err != nil && iden.Value != nil {
+			responsiblePractitioner = *iden.Value
+		}
+	} else {
+		// If the request is not mandated the (Dezi) authenticated practitioner is responsible
+		responsiblePractitioner = input.Subject.User.Id
+	}
+
+	req := xacml.AuthzRequest{
 		PatientBSN:             input.Context.PatientBSN,
 		HealthcareFacilityType: input.Context.DataHolderFacilityType,
 		AuthorInstitutionID:    input.Context.DataHolderOrganizationId,
 		// This code is always the same, it's the code for _de gesloten vraag_
 		EventCode:              "GGC002",
 		SubjectRole:            input.Subject.User.Role,
-		ProviderID:             input.Subject.User.Id,
+		ProviderID:             responsiblePractitioner,
 		ProviderInstitutionID:  input.Subject.Organization.Ura,
 		ConsultingFacilityType: input.Subject.Organization.FacilityType,
 		PurposeOfUse:           "TREAT",
 	}
+
+	if isDelegated {
+		// If the request is mandated add the practitioner that has been delegated to
+		req.MandatedID = to.Ptr(input.Subject.User.Id)
+	}
+	return req
 }
 
 func validateMitzInput(input PolicyInput) []ResultReason {
@@ -73,19 +95,19 @@ func validateMitzInput(input PolicyInput) []ResultReason {
 		},
 		{
 			Value:   input.Subject.User.Role,
-			Message: "Could not complete Mitz consent check: Missing subject role",
+			Message: "Could not complete Mitz consent check: Missing subject user role",
 		},
 		{
 			Value:   input.Subject.User.Id,
-			Message: "Could not complete Mitz consent check: Missing subject id",
+			Message: "Could not complete Mitz consent check: Missing subject user id",
 		},
 		{
 			Value:   input.Subject.Organization.Ura,
-			Message: "Could not complete Mitz consent check: Missing subject organization ID",
+			Message: "Could not complete Mitz consent check: Missing subject organization URA",
 		},
 		{
 			Value:   input.Subject.Organization.FacilityType,
-			Message: "Could not complete Mitz consent check: Missing subject facility type",
+			Message: "Could not complete Mitz consent check: Missing subject organization facility type",
 		},
 	}
 

--- a/component/pdp/mitz_test.go
+++ b/component/pdp/mitz_test.go
@@ -46,7 +46,7 @@ func TestComponent_xacmlFromInput_Delegation(t *testing.T) {
 		delegatorID   = "000012345"
 		delegatorRole = "30.000"
 		regByToken    = "http://fhir.nl/fhir/NamingSystem/uzi-nr-pers|" + delegatorID
-		roleCodeToken = "2.16.840.1.113883.2.4.15.111|" + delegatorRole
+		roleCodeToken = "http://fhir.nl/fhir/NamingSystem/role-code-pers|" + delegatorRole
 	)
 
 	t.Run("uses delegating practitioner as responsible and sets MandatedID to authenticated user", func(t *testing.T) {

--- a/component/pdp/mitz_test.go
+++ b/component/pdp/mitz_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestComponent_map_input_xacml(t *testing.T) {
-	input := PolicyInput{
+func baseMitzInput() PolicyInput {
+	return PolicyInput{
 		Subject: PolicySubject{
 			User: PolicySubjectUser{
 				Id:   "000095254",
@@ -24,14 +25,101 @@ func TestComponent_map_input_xacml(t *testing.T) {
 			DataHolderOrganizationId: "00000659",
 		},
 	}
+}
 
-	xacml := xacmlFromInput(input)
-	assert.Equal(t, "900186021", xacml.PatientBSN)
-	assert.Equal(t, "01.015", xacml.SubjectRole)
-	assert.Equal(t, "000095254", xacml.ProviderID)
-	assert.Equal(t, "00000666", xacml.ProviderInstitutionID)
-	assert.Equal(t, "Z3", xacml.ConsultingFacilityType)
-	assert.Equal(t, "00000659", xacml.AuthorInstitutionID)
-	assert.Equal(t, "Z3", xacml.HealthcareFacilityType)
-	assert.Equal(t, "TREAT", xacml.PurposeOfUse)
+func TestComponent_map_input_xacml(t *testing.T) {
+	req, err := xacmlFromInput(baseMitzInput())
+	require.NoError(t, err)
+	assert.Equal(t, "900186021", req.PatientBSN)
+	assert.Equal(t, "01.015", req.SubjectRole)
+	assert.Equal(t, "000095254", req.ProviderID)
+	assert.Equal(t, "00000666", req.ProviderInstitutionID)
+	assert.Equal(t, "Z3", req.ConsultingFacilityType)
+	assert.Equal(t, "00000659", req.AuthorInstitutionID)
+	assert.Equal(t, "Z3", req.HealthcareFacilityType)
+	assert.Equal(t, "TREAT", req.PurposeOfUse)
+	assert.Nil(t, req.MandatedID, "MandatedID should not be set when no delegation is present")
+}
+
+func TestComponent_xacmlFromInput_Delegation(t *testing.T) {
+	const (
+		delegatorID   = "000012345"
+		delegatorRole = "30.000"
+		regByToken    = "http://fhir.nl/fhir/NamingSystem/uzi-nr-pers|" + delegatorID
+		roleCodeToken = "2.16.840.1.113883.2.4.15.111|" + delegatorRole
+	)
+
+	t.Run("uses delegating practitioner as responsible and sets MandatedID to authenticated user", func(t *testing.T) {
+		input := baseMitzInput()
+		input.Subject.OtherProps = OtherProps{
+			"delegation_registered_by": regByToken,
+			"delegation_role_code":     roleCodeToken,
+		}
+
+		req, err := xacmlFromInput(input)
+		require.NoError(t, err)
+		assert.Equal(t, delegatorID, req.ProviderID, "ProviderID should be the practitioner who delegated")
+		assert.Equal(t, delegatorRole, req.SubjectRole, "SubjectRole should be the delegated role")
+		require.NotNil(t, req.MandatedID, "MandatedID should be set on a delegated request")
+		assert.Equal(t, "000095254", *req.MandatedID, "MandatedID should be the authenticated user's id")
+	})
+
+	t.Run("returns error when delegation_role_code is missing", func(t *testing.T) {
+		input := baseMitzInput()
+		input.Subject.OtherProps = OtherProps{
+			"delegation_registered_by": regByToken,
+		}
+
+		_, err := xacmlFromInput(input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing delegation_role_code")
+	})
+
+	t.Run("returns error when delegation_registered_by is empty", func(t *testing.T) {
+		input := baseMitzInput()
+		input.Subject.OtherProps = OtherProps{
+			"delegation_registered_by": "",
+			"delegation_role_code":     roleCodeToken,
+		}
+
+		_, err := xacmlFromInput(input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid format for delegation_registered_by")
+	})
+
+	t.Run("returns error when delegation_registered_by has no system|value separator", func(t *testing.T) {
+		input := baseMitzInput()
+		input.Subject.OtherProps = OtherProps{
+			"delegation_registered_by": "no-pipe-here",
+			"delegation_role_code":     roleCodeToken,
+		}
+
+		_, err := xacmlFromInput(input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid format for delegation_registered_by")
+	})
+
+	t.Run("returns error when delegation_registered_by has only system, no value", func(t *testing.T) {
+		input := baseMitzInput()
+		input.Subject.OtherProps = OtherProps{
+			"delegation_registered_by": "http://fhir.nl/fhir/NamingSystem/uzi-nr-pers|",
+			"delegation_role_code":     roleCodeToken,
+		}
+
+		_, err := xacmlFromInput(input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid format for delegation_registered_by")
+	})
+
+	t.Run("returns error when delegation_role_code is malformed", func(t *testing.T) {
+		input := baseMitzInput()
+		input.Subject.OtherProps = OtherProps{
+			"delegation_registered_by": regByToken,
+			"delegation_role_code":     "garbage",
+		}
+
+		_, err := xacmlFromInput(input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "delegation_role_code")
+	})
 }

--- a/component/pdp/mitz_test.go
+++ b/component/pdp/mitz_test.go
@@ -46,7 +46,7 @@ func TestComponent_xacmlFromInput_Delegation(t *testing.T) {
 		delegatorID   = "000012345"
 		delegatorRole = "30.000"
 		regByToken    = "http://fhir.nl/fhir/NamingSystem/uzi-nr-pers|" + delegatorID
-		roleCodeToken = "http://fhir.nl/fhir/NamingSystem/uzi-rolcode" + delegatorRole
+		roleCodeToken = "http://fhir.nl/fhir/NamingSystem/uzi-rolcode|" + delegatorRole
 	)
 
 	t.Run("uses delegating practitioner as responsible and sets MandatedID to authenticated user", func(t *testing.T) {

--- a/component/pdp/mitz_test.go
+++ b/component/pdp/mitz_test.go
@@ -46,7 +46,7 @@ func TestComponent_xacmlFromInput_Delegation(t *testing.T) {
 		delegatorID   = "000012345"
 		delegatorRole = "30.000"
 		regByToken    = "http://fhir.nl/fhir/NamingSystem/uzi-nr-pers|" + delegatorID
-		roleCodeToken = "http://fhir.nl/fhir/NamingSystem/role-code-pers|" + delegatorRole
+		roleCodeToken = "http://fhir.nl/fhir/NamingSystem/uzi-rolcode" + delegatorRole
 	)
 
 	t.Run("uses delegating practitioner as responsible and sets MandatedID to authenticated user", func(t *testing.T) {

--- a/component/pdp/shared.go
+++ b/component/pdp/shared.go
@@ -29,8 +29,6 @@ type APISubject struct {
 	OrganizationUra          string         `json:"organization_ura"`
 	OrganizationName         string         `json:"organization_name"`
 	OrganizationFacilityType string         `json:"organization_facility_type"`
-	DelegationRegisteredBy   string         `json:"delegation_registered_by"`
-	DelegationRoleCode       string         `json:"delegation_role_code"`
 }
 
 var _ json.Unmarshaler = (*APISubject)(nil)

--- a/component/pdp/shared.go
+++ b/component/pdp/shared.go
@@ -29,6 +29,8 @@ type APISubject struct {
 	OrganizationUra          string         `json:"organization_ura"`
 	OrganizationName         string         `json:"organization_name"`
 	OrganizationFacilityType string         `json:"organization_facility_type"`
+	DelegationRegisteredBy   string         `json:"delegation_registered_by"`
+	DelegationRoleCode       string         `json:"delegation_role_code"`
 }
 
 var _ json.Unmarshaler = (*APISubject)(nil)
@@ -141,6 +143,10 @@ type PolicySubjectOrganization struct {
 type PolicySubjectUser struct {
 	Id   string `json:"id"`
 	Role string `json:"role"`
+}
+type PolicySubjectDelegation struct {
+	RegisteredBy string `json:"registered_by"`
+	RoleCode     string `json:"role_code"`
 }
 
 func NewPolicySubject(apiSubject APISubject) PolicySubject {

--- a/component/pdp/shared.go
+++ b/component/pdp/shared.go
@@ -142,10 +142,6 @@ type PolicySubjectUser struct {
 	Id   string `json:"id"`
 	Role string `json:"role"`
 }
-type PolicySubjectDelegation struct {
-	RegisteredBy string `json:"registered_by"`
-	RoleCode     string `json:"role_code"`
-}
 
 func NewPolicySubject(apiSubject APISubject) PolicySubject {
 

--- a/test/e2e/pep/authorization_test.go
+++ b/test/e2e/pep/authorization_test.go
@@ -374,8 +374,8 @@ func requestAccessToken(t *testing.T, nutsAPI func(string) string, subject, auth
 			"@context": []string{"https://www.w3.org/2018/credentials/v1"},
 			"type":     []string{"VerifiableCredential", "HealthCareProfessionalDelegationCredential"},
 			"credentialSubject": map[string]any{
-				"registeredBy": "urn:oid:2.16.528.1.1007.3.1.12345",
-				"roleCode":     "01.015",
+				"registeredBy": "http://fhir.nl/fhir/NamingSystem/uzi-nr-pers|000012345",
+				"roleCode":     "http://fhir.nl/fhir/NamingSystem/role-code-pers|01.015",
 				"facilityType": "Z3",
 			},
 		},


### PR DESCRIPTION
When a request is made under a HealthCareProfessionalDelegationCredential (mandaat), the Mitz consent query needs to identify both the delegating practitioner (legally responsible) and the delegated-to practitioner (the one actually performing the action). This change wires that through the PDP -> XACML pipeline.