### PR TITLE
Make Nuts policy directory path work for both Docker and host runs

### DIFF
--- a/config/nuts.yml
+++ b/config/nuts.yml
@@ -7,4 +7,4 @@ auth:
     - dummy
 
 policy:
-  directory: "/app/config/policy"
+  directory: "./config/policy"


### PR DESCRIPTION
The Nuts node policy directory was hardcoded to /app/config/policy, the absolute path inside the Docker container where ./config is bind-mounted. This worked under docker compose but broke when running knooppunt directly on a developer machine, where /app/config doesn't exist.

Changing it to the relative path ./config/policy resolves correctly in both environments:
- In the container, cwd is /app (set via WORKDIR in the Dockerfile), so it resolves to /app/config/policy.
- On a host run, cwd is the project root, so it resolves to <repo>/config/policy.