### PR TITLE
Refactor MCSD component to be more readable

### DIFF
--- a/component/mcsd/component.go
+++ b/component/mcsd/component.go
@@ -102,6 +102,7 @@ type administrationDirectory struct {
 	fhirBaseURL      string
 	resourceTypes    []string
 	discover         bool
+	trusted          bool   // Skip validation checks on this directory's contents
 	sourceURL        string // The fullUrl from the Bundle entry that created this Endpoint, used for unregistration on DELETE
 	authoritativeUra string // URA of the organization that is authoritative for this directory
 }
@@ -148,7 +149,7 @@ func New(config Config) (*Component, error) {
 		updateMux:              &sync.RWMutex{},
 	}
 	for _, rootDirectory := range config.AdministrationDirectories {
-		if err := result.registerAdministrationDirectory(context.Background(), rootDirectory.FHIRBaseURL, rootDirectoryResourceTypes, true, "", ""); err != nil {
+		if err := result.registerAdministrationDirectory(context.Background(), rootDirectory.FHIRBaseURL, rootDirectoryResourceTypes, true, "", "", rootDirectory.Trusted); err != nil {
 			return nil, fmt.Errorf("register root administration directory (url=%s): %w", rootDirectory.FHIRBaseURL, err)
 		}
 	}
@@ -181,7 +182,7 @@ func (c *Component) RegisterHttpHandlers(publicMux, internalMux *http.ServeMux) 
 	})
 }
 
-func (c *Component) registerAdministrationDirectory(ctx context.Context, fhirBaseURL string, resourceTypes []string, discover bool, sourceURL string, authoritativeUra string) error {
+func (c *Component) registerAdministrationDirectory(ctx context.Context, fhirBaseURL string, resourceTypes []string, discover bool, sourceURL string, authoritativeUra string, trusted bool) error {
 	// Must be a valid http or https URL
 	parsedFHIRBaseURL, err := url.Parse(fhirBaseURL)
 	if err != nil {
@@ -211,10 +212,11 @@ func (c *Component) registerAdministrationDirectory(ctx context.Context, fhirBas
 		resourceTypes:    resourceTypes,
 		fhirBaseURL:      fhirBaseURL,
 		discover:         discover,
+		trusted:          trusted,
 		sourceURL:        sourceURL,
 		authoritativeUra: authoritativeUra,
 	})
-	slog.InfoContext(ctx, "Registered mCSD Directory", logging.FHIRServer(fhirBaseURL), slog.Bool("discover", discover))
+	slog.InfoContext(ctx, "Registered mCSD Directory", logging.FHIRServer(fhirBaseURL), slog.Bool("discover", discover), slog.Bool("trusted", trusted))
 	return nil
 }
 
@@ -325,7 +327,7 @@ func (c *Component) discoverAndRegisterEndpoints(ctx context.Context, entries []
 			if coding.CodablesIncludesCode(endpoint.PayloadType, payloadCoding) {
 				slog.DebugContext(ctx, "Discovered mCSD Directory", slog.String("address", endpoint.Address))
 
-				err := c.registerAdministrationDirectory(ctx, endpoint.Address, c.directoryResourceTypes, false, fullUrl, authoritativeUra)
+				err := c.registerAdministrationDirectory(ctx, endpoint.Address, c.directoryResourceTypes, false, fullUrl, authoritativeUra, false)
 				if err != nil {
 					report.Warnings = append(report.Warnings, fmt.Sprintf("failed to register discovered mCSD Directory at %s: %s", endpoint.Address, err.Error()))
 				}

--- a/component/mcsd/component.go
+++ b/component/mcsd/component.go
@@ -444,7 +444,7 @@ func (c *Component) updateFromDirectory(ctx context.Context, fhirBaseURLRaw stri
 			continue
 		}
 		slog.DebugContext(ctx, "Processing entry", logging.FHIRServer(fhirBaseURLRaw), slog.String("url", entry.Request.Url))
-		_, err := buildUpdateTransaction(ctx, &tx, entry, ValidationRules{AllowedResourceTypes: allowedResourceTypes}, parentOrganizationsMap, allHealthcareServices, allowDiscovery, fhirBaseURLRaw)
+		_, err := buildUpdateTransaction(ctx, &tx, entry, ValidationRules{AllowedResourceTypes: allowedResourceTypes, Trusted: trusted}, parentOrganizationsMap, allHealthcareServices, allowDiscovery, fhirBaseURLRaw)
 		if err != nil {
 			report.Warnings = append(report.Warnings, fmt.Sprintf("entry #%d: %s", i, err.Error()))
 			continue

--- a/component/mcsd/component.go
+++ b/component/mcsd/component.go
@@ -64,6 +64,11 @@ func makeDirectoryKey(fhirBaseURL, authoritativeUra string) string {
 //   - have the same mcsd-directory-endpoint as the directory being queried
 //   - These are mitigating measures to prevent an attacker to spoof another care organization.
 //   - The organization's mcsd-directory-endpoint must be discoverable through the root mCSD Directory.'
+//
+// A root directory may be marked as 'trusted' (DirectoryConfig.Trusted), which skips the per-resource
+// validation described above. This is intended for directories the operator controls or
+// otherwise trusts (e.g. the LRZA). Trust does not affect sync cadence — incremental sync via _since
+// still applies. Directories discovered from a trusted root are always registered as untrusted.
 type Component struct {
 	config            Config
 	fhirAdminClientFn func(baseURL *url.URL) fhirclient.Client

--- a/component/mcsd/component.go
+++ b/component/mcsd/component.go
@@ -91,6 +91,9 @@ type Config struct {
 
 type DirectoryConfig struct {
 	FHIRBaseURL string `koanf:"fhirbaseurl"`
+	// Trusted disables anti-spoofing validation on this directory's contents.
+	// Only safe for directories you control or otherwise trust (like the LRZA).
+	Trusted bool `koanf:"trusted"`
 }
 
 type UpdateReport map[string]DirectoryUpdateReport

--- a/component/mcsd/component.go
+++ b/component/mcsd/component.go
@@ -255,7 +255,7 @@ func (c *Component) update(ctx context.Context) (UpdateReport, error) {
 	result := make(UpdateReport)
 	for i := 0; i < len(c.administrationDirectories); i++ {
 		adminDirectory := c.administrationDirectories[i]
-		report, err := c.updateFromDirectory(ctx, adminDirectory.fhirBaseURL, adminDirectory.resourceTypes, adminDirectory.discover, adminDirectory.authoritativeUra)
+		report, err := c.updateFromDirectory(ctx, adminDirectory.fhirBaseURL, adminDirectory.resourceTypes, adminDirectory.discover, adminDirectory.authoritativeUra, adminDirectory.trusted)
 		if err != nil {
 			slog.ErrorContext(ctx, "mCSD Directory update failed", logging.FHIRServer(adminDirectory.fhirBaseURL), logging.Error(err))
 			report.Errors = append(report.Errors, err.Error())
@@ -338,8 +338,8 @@ func (c *Component) discoverAndRegisterEndpoints(ctx context.Context, entries []
 	return report
 }
 
-func (c *Component) updateFromDirectory(ctx context.Context, fhirBaseURLRaw string, allowedResourceTypes []string, allowDiscovery bool, authoritativeUra string) (DirectoryUpdateReport, error) {
-	slog.InfoContext(ctx, "Updating from mCSD Directory", logging.FHIRServer(fhirBaseURLRaw), slog.Bool("discover", allowDiscovery), slog.Any("resourceTypes", allowedResourceTypes))
+func (c *Component) updateFromDirectory(ctx context.Context, fhirBaseURLRaw string, allowedResourceTypes []string, allowDiscovery bool, authoritativeUra string, trusted bool) (DirectoryUpdateReport, error) {
+	slog.InfoContext(ctx, "Updating from mCSD Directory", logging.FHIRServer(fhirBaseURLRaw), slog.Bool("discover", allowDiscovery), slog.Bool("trusted", trusted), slog.Any("resourceTypes", allowedResourceTypes))
 	remoteAdminDirectoryFHIRBaseURL, err := url.Parse(fhirBaseURLRaw)
 	if err != nil {
 		return DirectoryUpdateReport{}, err
@@ -371,16 +371,20 @@ func (c *Component) updateFromDirectory(ctx context.Context, fhirBaseURLRaw stri
 		return DirectoryUpdateReport{}, err
 	}
 
-	// Check if any Organization's URA identifier has changed between history versions
-	uraIdentifierChanged := checkForURAIdentifierChanges(entries)
-	if uraIdentifierChanged {
-		slog.WarnContext(ctx, "Detected URA identifier change in organization history. Rerunning history query without _since parameter.", logging.FHIRServer(fhirBaseURLRaw))
+	// Check if any Organization's URA identifier has changed between history versions.
+	// Skipped for trusted directories: a URA change is synced like any other change,
+	// since we don't validate against URA identifiers in trusted mode.
+	if !trusted {
+		uraIdentifierChanged := checkForURAIdentifierChanges(entries)
+		if uraIdentifierChanged {
+			slog.WarnContext(ctx, "Detected URA identifier change in organization history. Rerunning history query without _since parameter.", logging.FHIRServer(fhirBaseURLRaw))
 
-		// Remove _since parameter and rerun the query
-		searchParams.Del("_since")
-		entries, firstSearchSet, err = c.queryAllResourceTypes(ctx, remoteAdminDirectoryFHIRClient, allowedResourceTypes, searchParams)
-		if err != nil {
-			return DirectoryUpdateReport{}, err
+			// Remove _since parameter and rerun the query
+			searchParams.Del("_since")
+			entries, firstSearchSet, err = c.queryAllResourceTypes(ctx, remoteAdminDirectoryFHIRClient, allowedResourceTypes, searchParams)
+			if err != nil {
+				return DirectoryUpdateReport{}, err
+			}
 		}
 	}
 
@@ -406,17 +410,24 @@ func (c *Component) updateFromDirectory(ctx context.Context, fhirBaseURLRaw stri
 		c.processEndpointDeletes(ctx, deduplicatedEntries)
 	}
 
-	// Find parent organizations with URA identifier and all organizations linked to them
-	// This is used when validating organizations that don't have their own URA identifier
-	parentOrganizationsMap, err := c.ensureParentOrganizationsMap(ctx, fhirBaseURLRaw, remoteAdminDirectoryFHIRClient, authoritativeUra)
-
-	if err != nil {
-		return DirectoryUpdateReport{}, fmt.Errorf("failed to build parent organization map: %w", err)
+	// Find parent organizations with URA identifier and all organizations linked to them.
+	// Used both for validating organizations that don't have their own URA identifier and
+	// for endpoint discovery. For trusted directories without discovery, neither applies
+	// so the map stays nil.
+	var parentOrganizationsMap parentOrganizationMap
+	if !trusted || allowDiscovery {
+		parentOrganizationsMap, err = c.ensureParentOrganizationsMap(ctx, fhirBaseURLRaw, remoteAdminDirectoryFHIRClient, authoritativeUra)
+		if err != nil {
+			return DirectoryUpdateReport{}, fmt.Errorf("failed to build parent organization map: %w", err)
+		}
 	}
 
-	// Validate all parent organizations once before processing resources
-	if err := ValidateParentOrganizations(parentOrganizationsMap); err != nil {
-		return DirectoryUpdateReport{}, fmt.Errorf("parent organization (one that supposedly has ura identifier - and only only) validation failed: %w", err)
+	// Validate all parent organizations once before processing resources.
+	// Skipped for trusted directories.
+	if !trusted {
+		if err := ValidateParentOrganizations(parentOrganizationsMap); err != nil {
+			return DirectoryUpdateReport{}, fmt.Errorf("parent organization (one that supposedly has ura identifier - and only only) validation failed: %w", err)
+		}
 	}
 
 	// Build transaction with deterministic conditional references

--- a/component/mcsd/component.go
+++ b/component/mcsd/component.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,7 +19,6 @@ import (
 	libfhir "github.com/nuts-foundation/nuts-knooppunt/lib/fhirutil"
 	"github.com/nuts-foundation/nuts-knooppunt/lib/httpauth"
 	"github.com/nuts-foundation/nuts-knooppunt/lib/logging"
-	"github.com/zorgbijjou/golang-fhir-models/fhir-models/caramel/to"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 )
 
@@ -120,6 +118,53 @@ type DirectoryUpdateReport struct {
 	Errors       []string `json:"errors"`
 }
 
+// syncRun holds everything needed to sync a single administration directory into the query
+// directory. The config fields (top) describe *what* to sync and are set when the run is
+// constructed; the working-state fields (bottom) are filled while the run executes. Bundling them
+// in one value lets the sync steps read as named intent instead of branching on positional bools.
+type syncRun struct {
+	// config
+	fhirBaseURL      string
+	allowedTypes     []string
+	authoritativeUra string
+	trusted          bool
+	discoverable     bool // only used to compute the import filter; discovery itself is a separate phase
+
+	// working state
+	remoteClient   fhirclient.Client
+	queryStart     time.Time
+	searchParams   url.Values
+	entries        []fhir.BundleEntry
+	firstSearchSet fhir.Bundle
+	parentOrgs     parentOrganizationMap
+	healthcareSvcs []fhir.HealthcareService
+}
+
+func (d administrationDirectory) newSyncRun() *syncRun {
+	return &syncRun{
+		fhirBaseURL:      d.fhirBaseURL,
+		allowedTypes:     d.resourceTypes,
+		authoritativeUra: d.authoritativeUra,
+		trusted:          d.trusted,
+		discoverable:     d.discover,
+	}
+}
+
+func (r *syncRun) key() string { return makeDirectoryKey(r.fhirBaseURL, r.authoritativeUra) }
+
+// validates reports whether this directory's contents must pass anti-spoofing validation.
+// Trusted directories are imported as-is, so they skip validation entirely.
+func (r *syncRun) validates() bool { return !r.trusted }
+
+// onlyDirectoryEndpoints reports whether the sync should import only mCSD directory Endpoints.
+// This is true for an untrusted discoverable root: it is crawled for discovery, but its resource
+// data is taken from the validated leaf directories rather than imported wholesale.
+func (r *syncRun) onlyDirectoryEndpoints() bool { return r.discoverable && !r.trusted }
+
+func (r *syncRun) validationRules() ValidationRules {
+	return ValidationRules{AllowedResourceTypes: r.allowedTypes, Trusted: r.trusted}
+}
+
 func New(config Config) (*Component, error) {
 	// Create HTTP client with optional OAuth2 authentication
 	var httpClient *http.Client
@@ -187,83 +232,38 @@ func (c *Component) RegisterHttpHandlers(publicMux, internalMux *http.ServeMux) 
 	})
 }
 
-func (c *Component) registerAdministrationDirectory(ctx context.Context, fhirBaseURL string, resourceTypes []string, discover bool, sourceURL string, authoritativeUra string, trusted bool) error {
-	// Must be a valid http or https URL
-	parsedFHIRBaseURL, err := url.Parse(fhirBaseURL)
-	if err != nil {
-		return fmt.Errorf("invalid FHIR base URL (url=%s): %w", fhirBaseURL, err)
-	}
-	parsedFHIRBaseURL.Scheme = strings.ToLower(parsedFHIRBaseURL.Scheme)
-	if (parsedFHIRBaseURL.Scheme != "https" && parsedFHIRBaseURL.Scheme != "http") || parsedFHIRBaseURL.Host == "" {
-		return fmt.Errorf("invalid FHIR base URL (url=%s)", fhirBaseURL)
-	}
-
-	// Check if the URL is in the exclusion list (also trim exclusion list entries for consistent matching)
-	trimmedFHIRBaseURL := strings.TrimRight(fhirBaseURL, "/")
-	for _, excludedURL := range c.config.ExcludeAdminDirectories {
-		if strings.TrimRight(excludedURL, "/") == trimmedFHIRBaseURL {
-			slog.InfoContext(ctx, "Skipping administration directory registration: excluded by configuration", logging.FHIRServer(fhirBaseURL))
-			return nil
-		}
-	}
-
-	exists := slices.ContainsFunc(c.administrationDirectories, func(directory administrationDirectory) bool {
-		return directory.fhirBaseURL == fhirBaseURL && directory.authoritativeUra == authoritativeUra
-	})
-	if exists {
-		return nil
-	}
-	c.administrationDirectories = append(c.administrationDirectories, administrationDirectory{
-		resourceTypes:    resourceTypes,
-		fhirBaseURL:      fhirBaseURL,
-		discover:         discover,
-		trusted:          trusted,
-		sourceURL:        sourceURL,
-		authoritativeUra: authoritativeUra,
-	})
-	slog.InfoContext(ctx, "Registered mCSD Directory", logging.FHIRServer(fhirBaseURL), slog.Bool("discover", discover), slog.Bool("trusted", trusted))
-	return nil
-}
-
-// unregisterAdministrationDirectory removes an administration directory from the list by its fullUrl.
-// This is called when an Endpoint is deleted to prevent it from being fetched in future updates.
-// The fullUrl parameter is the Bundle entry fullUrl that was used when the Endpoint was registered.
-func (c *Component) unregisterAdministrationDirectory(ctx context.Context, fullUrl string) {
-	initialCount := len(c.administrationDirectories)
-	c.administrationDirectories = slices.DeleteFunc(c.administrationDirectories, func(dir administrationDirectory) bool {
-		return dir.sourceURL == fullUrl
-	})
-	if len(c.administrationDirectories) < initialCount {
-		slog.InfoContext(ctx, "Unregistered mCSD Directory after Endpoint deletion", slog.String("full_url", fullUrl))
-	}
-}
-
-// processEndpointDeletes processes DELETE operations for Endpoints and unregisters them from administrationDirectories.
-// This prevents deleted Endpoints from being fetched in future updates, fixing issue #241.
-func (c *Component) processEndpointDeletes(ctx context.Context, entries []fhir.BundleEntry) {
-	for _, entry := range entries {
-		if entry.Request != nil && entry.Request.Method == fhir.HTTPVerbDELETE && entry.FullUrl != nil {
-			parts := strings.Split(entry.Request.Url, "/")
-			if len(parts) >= 2 && parts[0] == "Endpoint" {
-				// Unregister the administration directory using the fullUrl
-				// The fullUrl uniquely identifies the resource that was deleted
-				c.unregisterAdministrationDirectory(ctx, *entry.FullUrl)
-			}
-		}
-	}
-}
-
+// update runs a full refresh cycle in two phases: first discovery, then sync.
+//
+// Phase 1 (discovery) crawls discoverable (root) directories and registers/unregisters the
+// administration directories they point at; it only mutates c.administrationDirectories.
+// Phase 2 (sync) imports resources from every administration directory — roots and the ones just
+// discovered — into the query directory. Running discovery to completion first means a directory
+// discovered this cycle is synced in the same cycle. Warnings/errors from discovery are merged into
+// the sync report for the same directory.
+//
+// As a result a discoverable root is queried twice per cycle (a full scan in phase 1, then an
+// incremental query in phase 2). This is intentional: the phases do different work — discovery only
+// updates the in-memory registry, while sync imports the root's own mCSD directory Endpoints into
+// the query directory. The separation is kept deliberately even though it costs the extra query.
 func (c *Component) update(ctx context.Context) (UpdateReport, error) {
 	c.updateMux.Lock()
 	defer c.updateMux.Unlock()
 
-	result := make(UpdateReport)
-	for i := 0; i < len(c.administrationDirectories); i++ {
-		adminDirectory := c.administrationDirectories[i]
-		report, err := c.updateFromDirectory(ctx, adminDirectory.fhirBaseURL, adminDirectory.resourceTypes, adminDirectory.discover, adminDirectory.authoritativeUra, adminDirectory.trusted)
+	// Phase 1: discovery.
+	result := c.discover(ctx)
+
+	// Phase 2: sync.
+	for _, adminDirectory := range c.administrationDirectories {
+		run := adminDirectory.newSyncRun()
+		report, err := c.runSyncJob(ctx, run)
 		if err != nil {
-			slog.ErrorContext(ctx, "mCSD Directory update failed", logging.FHIRServer(adminDirectory.fhirBaseURL), logging.Error(err))
+			slog.ErrorContext(ctx, "mCSD Directory update failed", logging.FHIRServer(run.fhirBaseURL), logging.Error(err))
 			report.Errors = append(report.Errors, err.Error())
+		}
+		// Merge discovery-phase warnings/errors for the same directory (roots only).
+		if discoveryReport, ok := result[run.key()]; ok {
+			report.Warnings = append(discoveryReport.Warnings, report.Warnings...)
+			report.Errors = append(discoveryReport.Errors, report.Errors...)
 		}
 		// Return empty slices instead of null ones, makes a nicer REST API
 		if report.Warnings == nil {
@@ -272,170 +272,133 @@ func (c *Component) update(ctx context.Context) (UpdateReport, error) {
 		if report.Errors == nil {
 			report.Errors = []string{}
 		}
-		directoryKey := makeDirectoryKey(adminDirectory.fhirBaseURL, adminDirectory.authoritativeUra)
-		result[directoryKey] = report
+		result[run.key()] = report
 	}
 	return result, nil
 }
 
-// discoverAndRegisterEndpoints processes endpoint discovery and registration for the given parent organizations.
-// It finds endpoints from the entries that match parent organization endpoint references and registers them.
-func (c *Component) discoverAndRegisterEndpoints(ctx context.Context, entries []fhir.BundleEntry, parentOrganizationsMap parentOrganizationMap, report DirectoryUpdateReport) DirectoryUpdateReport {
-	if parentOrganizationsMap == nil {
-		return report
+// runSyncJob imports resources from a single administration directory into the query directory.
+// Discovery of new directories is a separate phase (see discover); this only syncs resources, so
+// every directory — root or discovered — is treated the same here. It reads as the sequence of
+// steps documented on each helper.
+func (c *Component) runSyncJob(ctx context.Context, run *syncRun) (DirectoryUpdateReport, error) {
+	slog.InfoContext(ctx, "Updating from mCSD Directory", logging.FHIRServer(run.fhirBaseURL), slog.Bool("trusted", run.trusted), slog.Any("resourceTypes", run.allowedTypes))
+
+	if err := c.startSyncRun(ctx, run); err != nil {
+		return DirectoryUpdateReport{}, err
+	}
+	if err := c.fetchEntries(ctx, run); err != nil {
+		return DirectoryUpdateReport{}, err
+	}
+	if err := c.loadParentOrgs(ctx, run); err != nil {
+		return DirectoryUpdateReport{}, err
 	}
 
-	for parentOrg := range parentOrganizationsMap {
-		uraIdentifiers := libfhir.FilterIdentifiersBySystem(parentOrg.Identifier, coding.URANamingSystem)
-		if len(uraIdentifiers) == 0 || uraIdentifiers[0].Value == nil {
-			continue
-		}
-		authoritativeUra := *uraIdentifiers[0].Value
+	// _history can return multiple versions of the same resource, but a transaction bundle must
+	// contain each resource at most once, so keep only the most recent version of each.
+	deduplicatedEntries := deduplicateHistoryEntries(run.entries)
+	report, tx := c.buildTransaction(ctx, run, deduplicatedEntries)
 
-		if parentOrg.Endpoint == nil || len(parentOrg.Endpoint) == 0 {
-			continue
-		}
-
-		// find endpoint in entries
-		endpoints := make(map[string]*fhir.Endpoint)
-		for _, entry := range entries {
-			if entry.Resource == nil {
-				continue
-			}
-			var endpoint fhir.Endpoint
-			if err := json.Unmarshal(entry.Resource, &endpoint); err != nil {
-				continue
-			}
-			// find all Endpoint resources from entries that reference the parent organization's Endpoint resources'
-			if endpoint.Id != nil {
-				endpointID := *endpoint.Id
-				for _, parentEndpoint := range parentOrg.Endpoint {
-					if parentEndpoint.Reference != nil {
-						refID := extractReferenceID(parentEndpoint.Reference)
-						if endpointID == refID {
-							if entry.FullUrl != nil {
-								endpoints[*entry.FullUrl] = &endpoint
-							}
-							break // Found a match, move to next entry
-						}
-					}
-				}
-			}
-		}
-
-		payloadCoding := fhir.Coding{
-			System: to.Ptr(coding.MCSDPayloadTypeSystem),
-			Code:   to.Ptr(coding.MCSDPayloadTypeDirectoryCode),
-		}
-
-		for fullUrl, endpoint := range endpoints {
-			if coding.CodablesIncludesCode(endpoint.PayloadType, payloadCoding) {
-				slog.DebugContext(ctx, "Discovered mCSD Directory", slog.String("address", endpoint.Address))
-
-				err := c.registerAdministrationDirectory(ctx, endpoint.Address, c.directoryResourceTypes, false, fullUrl, authoritativeUra, false)
-				if err != nil {
-					report.Warnings = append(report.Warnings, fmt.Sprintf("failed to register discovered mCSD Directory at %s: %s", endpoint.Address, err.Error()))
-				}
-			}
-		}
+	slog.DebugContext(ctx, "Got mCSD entries", logging.FHIRServer(run.fhirBaseURL), slog.Int("count", len(tx.Entry)))
+	if len(tx.Entry) == 0 {
+		return report, nil
 	}
 
-	return report
+	report, err := c.applyTransaction(ctx, tx, report)
+	if err != nil {
+		return DirectoryUpdateReport{}, err
+	}
+	c.recordSyncTimestamp(ctx, run)
+	return report, nil
 }
 
-func (c *Component) updateFromDirectory(ctx context.Context, fhirBaseURLRaw string, allowedResourceTypes []string, allowDiscovery bool, authoritativeUra string, trusted bool) (DirectoryUpdateReport, error) {
-	slog.InfoContext(ctx, "Updating from mCSD Directory", logging.FHIRServer(fhirBaseURLRaw), slog.Bool("discover", allowDiscovery), slog.Bool("trusted", trusted), slog.Any("resourceTypes", allowedResourceTypes))
-	remoteAdminDirectoryFHIRBaseURL, err := url.Parse(fhirBaseURLRaw)
+// startSyncRun resolves the remote FHIR client and sets up the search parameters, applying the
+// _since parameter for incremental sync when a previous sync timestamp is known for this directory.
+func (c *Component) startSyncRun(ctx context.Context, run *syncRun) error {
+	remoteBaseURL, err := url.Parse(run.fhirBaseURL)
 	if err != nil {
-		return DirectoryUpdateReport{}, err
+		return err
 	}
-	remoteAdminDirectoryFHIRClient := c.fhirAdminClientFn(remoteAdminDirectoryFHIRBaseURL)
-
-	queryDirectoryFHIRClient := c.fhirQueryClient
-
-	// Get last update time for incremental sync
-	directoryKey := makeDirectoryKey(fhirBaseURLRaw, authoritativeUra)
-	lastUpdate, hasLastUpdate := c.lastUpdateTimes[directoryKey]
-
+	run.remoteClient = c.fhirAdminClientFn(remoteBaseURL)
 	// Capture query start time as fallback for servers that don't provide Bundle meta.lastUpdated.
-	queryStartTime := time.Now()
+	run.queryStart = time.Now()
 
-	searchParams := url.Values{
+	run.searchParams = url.Values{
 		"_count": []string{strconv.Itoa(searchPageSize)},
 	}
-	if hasLastUpdate {
-		searchParams.Set("_since", lastUpdate)
-		slog.DebugContext(ctx, "Using _since parameter for incremental sync from FHIR server", logging.FHIRServer(fhirBaseURLRaw), slog.String("_since", lastUpdate))
+	if lastUpdate, ok := c.lastUpdateTimes[run.key()]; ok {
+		run.searchParams.Set("_since", lastUpdate)
+		slog.DebugContext(ctx, "Using _since parameter for incremental sync from FHIR server", logging.FHIRServer(run.fhirBaseURL), slog.String("_since", lastUpdate))
 	} else {
-		slog.InfoContext(ctx, "No last update time, doing full sync from FHIR server", logging.FHIRServer(fhirBaseURLRaw))
+		slog.InfoContext(ctx, "No last update time, doing full sync from FHIR server", logging.FHIRServer(run.fhirBaseURL))
 	}
+	return nil
+}
 
-	// Initial query
-	entries, firstSearchSet, err := c.queryAllResourceTypes(ctx, remoteAdminDirectoryFHIRClient, allowedResourceTypes, searchParams)
+// fetchEntries queries all allowed resource types and stores the results on the run. A URA
+// identifier change can't be expressed incrementally (the _since query would mask it), so when one
+// is detected the query is rerun in full. That check is skipped for trusted directories, which
+// don't validate against URA identifiers.
+func (c *Component) fetchEntries(ctx context.Context, run *syncRun) error {
+	entries, firstSearchSet, err := c.queryAllResourceTypes(ctx, run.remoteClient, run.allowedTypes, run.searchParams)
 	if err != nil {
-		return DirectoryUpdateReport{}, err
+		return err
 	}
 
-	// Check if any Organization's URA identifier has changed between history versions.
-	// Skipped for trusted directories: a URA change is synced like any other change,
-	// since we don't validate against URA identifiers in trusted mode.
-	if !trusted {
-		uraIdentifierChanged := checkForURAIdentifierChanges(entries)
-		if uraIdentifierChanged {
-			slog.WarnContext(ctx, "Detected URA identifier change in organization history. Rerunning history query without _since parameter.", logging.FHIRServer(fhirBaseURLRaw))
-
-			// Remove _since parameter and rerun the query
-			searchParams.Del("_since")
-			entries, firstSearchSet, err = c.queryAllResourceTypes(ctx, remoteAdminDirectoryFHIRClient, allowedResourceTypes, searchParams)
-			if err != nil {
-				return DirectoryUpdateReport{}, err
-			}
+	if run.validates() && checkForURAIdentifierChanges(entries) {
+		slog.WarnContext(ctx, "Detected URA identifier change in organization history. Rerunning history query without _since parameter.", logging.FHIRServer(run.fhirBaseURL))
+		run.searchParams.Del("_since")
+		entries, firstSearchSet, err = c.queryAllResourceTypes(ctx, run.remoteClient, run.allowedTypes, run.searchParams)
+		if err != nil {
+			return err
 		}
 	}
 
-	// Deduplicate resources from _history query - keep only the most recent version
-	// _history can return multiple versions of the same resource, but transaction bundles must have unique resources
-	deduplicatedEntries := deduplicateHistoryEntries(entries)
+	run.entries = entries
+	run.firstSearchSet = firstSearchSet
+	run.healthcareSvcs = extractHealthcareServices(entries)
+	return nil
+}
 
-	// Filter to only include HealthcareService resources
-	var allHealthcareServices []fhir.HealthcareService
+// extractHealthcareServices returns all HealthcareService resources among the entries. They are
+// collected up front because validating other resources may need to look them up.
+func extractHealthcareServices(entries []fhir.BundleEntry) []fhir.HealthcareService {
+	var result []fhir.HealthcareService
 	for _, entry := range entries {
 		if entry.Resource == nil {
 			continue
 		}
 		var healthcareService fhir.HealthcareService
 		if err := json.Unmarshal(entry.Resource, &healthcareService); err == nil {
-			// Successfully unmarshaled as HealthcareService
-			allHealthcareServices = append(allHealthcareServices, healthcareService)
+			result = append(result, healthcareService)
 		}
 	}
+	return result
+}
 
-	// Pre-process Endpoint DELETEs to unregister administration directories
-	if allowDiscovery {
-		c.processEndpointDeletes(ctx, deduplicatedEntries)
+// loadParentOrgs builds the map of parent organizations (those with a URA identifier) to their
+// linked children and validates it. Both are anti-spoofing measures used to validate organizations
+// that don't carry their own URA identifier, so for trusted directories the map stays nil and
+// nothing is validated.
+func (c *Component) loadParentOrgs(ctx context.Context, run *syncRun) error {
+	if !run.validates() {
+		return nil
 	}
-
-	// Find parent organizations with URA identifier and all organizations linked to them.
-	// Used both for validating organizations that don't have their own URA identifier and
-	// for endpoint discovery. For trusted directories without discovery, neither applies
-	// so the map stays nil.
-	var parentOrganizationsMap parentOrganizationMap
-	if !trusted || allowDiscovery {
-		parentOrganizationsMap, err = c.ensureParentOrganizationsMap(ctx, fhirBaseURLRaw, remoteAdminDirectoryFHIRClient, authoritativeUra)
-		if err != nil {
-			return DirectoryUpdateReport{}, fmt.Errorf("failed to build parent organization map: %w", err)
-		}
+	parentOrgs, err := c.ensureParentOrganizationsMap(ctx, run.fhirBaseURL, run.remoteClient, run.authoritativeUra)
+	if err != nil {
+		return fmt.Errorf("failed to build parent organization map: %w", err)
 	}
-
-	// Validate all parent organizations once before processing resources.
-	// Skipped for trusted directories.
-	if !trusted {
-		if err := ValidateParentOrganizations(parentOrganizationsMap); err != nil {
-			return DirectoryUpdateReport{}, fmt.Errorf("parent organization (one that supposedly has ura identifier - and only only) validation failed: %w", err)
-		}
+	if err := ValidateParentOrganizations(parentOrgs); err != nil {
+		return fmt.Errorf("parent organization (one that supposedly has ura identifier - and only only) validation failed: %w", err)
 	}
+	run.parentOrgs = parentOrgs
+	return nil
+}
 
-	// Build transaction with deterministic conditional references
+// buildTransaction converts the deduplicated entries into a FHIR transaction bundle with
+// deterministic conditional references. Entries that can't be processed are recorded as warnings
+// rather than failing the whole sync.
+func (c *Component) buildTransaction(ctx context.Context, run *syncRun, deduplicatedEntries []fhir.BundleEntry) (DirectoryUpdateReport, fhir.Bundle) {
 	tx := fhir.Bundle{
 		Type:  fhir.BundleTypeTransaction,
 		Entry: make([]fhir.BundleEntry, 0, len(deduplicatedEntries)),
@@ -444,38 +407,30 @@ func (c *Component) updateFromDirectory(ctx context.Context, fhirBaseURLRaw stri
 	var report DirectoryUpdateReport
 	for i, entry := range deduplicatedEntries {
 		if entry.Request == nil {
-			msg := fmt.Sprintf("Skipping entry with no request: #%d", i)
-			report.Warnings = append(report.Warnings, msg)
+			report.Warnings = append(report.Warnings, fmt.Sprintf("Skipping entry with no request: #%d", i))
 			continue
 		}
-		slog.DebugContext(ctx, "Processing entry", logging.FHIRServer(fhirBaseURLRaw), slog.String("url", entry.Request.Url))
-		_, err := buildUpdateTransaction(ctx, &tx, entry, ValidationRules{AllowedResourceTypes: allowedResourceTypes, Trusted: trusted}, parentOrganizationsMap, allHealthcareServices, allowDiscovery, fhirBaseURLRaw)
+		slog.DebugContext(ctx, "Processing entry", logging.FHIRServer(run.fhirBaseURL), slog.String("url", entry.Request.Url))
+		_, err := buildUpdateTransaction(ctx, &tx, entry, run.validationRules(), run.parentOrgs, run.healthcareSvcs, run.onlyDirectoryEndpoints(), run.fhirBaseURL)
 		if err != nil {
 			report.Warnings = append(report.Warnings, fmt.Sprintf("entry #%d: %s", i, err.Error()))
 			continue
 		}
 	}
+	return report, tx
+}
 
-	// Handle Endpoint discovery and registration
-	if allowDiscovery {
-		report = c.discoverAndRegisterEndpoints(ctx, entries, parentOrganizationsMap, report)
-	}
-
-	slog.DebugContext(ctx, "Got mCSD entries", logging.FHIRServer(fhirBaseURLRaw), slog.Int("count", len(tx.Entry)))
-	if len(tx.Entry) == 0 {
-		return report, nil
-	}
-
+// applyTransaction sends the transaction bundle to the query directory and tallies the per-entry
+// outcomes (created/updated/deleted) into the report.
+func (c *Component) applyTransaction(ctx context.Context, tx fhir.Bundle, report DirectoryUpdateReport) (DirectoryUpdateReport, error) {
 	var txResult fhir.Bundle
-	if err := queryDirectoryFHIRClient.CreateWithContext(ctx, tx, &txResult, fhirclient.AtPath("/")); err != nil {
+	if err := c.fhirQueryClient.CreateWithContext(ctx, tx, &txResult, fhirclient.AtPath("/")); err != nil {
 		return DirectoryUpdateReport{}, fmt.Errorf("failed to apply mCSD update to query directory: %w", err)
 	}
 
-	// Process result
 	for i, entry := range txResult.Entry {
 		if entry.Response == nil {
-			msg := fmt.Sprintf("Skipping entry with no response: #%d", i)
-			report.Warnings = append(report.Warnings, msg)
+			report.Warnings = append(report.Warnings, fmt.Sprintf("Skipping entry with no response: #%d", i))
 			continue
 		}
 		switch {
@@ -486,25 +441,24 @@ func (c *Component) updateFromDirectory(ctx context.Context, fhirBaseURLRaw stri
 		case strings.HasPrefix(entry.Response.Status, "204"):
 			report.CountDeleted++
 		default:
-			msg := fmt.Sprintf("Unknown HTTP response status %v (url=%v)", entry.Response.Status, entry.FullUrl)
-			report.Warnings = append(report.Warnings, msg)
+			report.Warnings = append(report.Warnings, fmt.Sprintf("Unknown HTTP response status %v (url=%v)", entry.Response.Status, entry.FullUrl))
 		}
 	}
-
-	// Update last sync timestamp on successful completion.
-	// Use the search result Bundle's meta.lastUpdated if available, otherwise fall back to query start time.
-	// This uses the FHIR server's own timestamp string, eliminating clock skew issues.
-	var nextSyncTime string
-	if firstSearchSet.Meta != nil && firstSearchSet.Meta.LastUpdated != nil {
-		nextSyncTime = *firstSearchSet.Meta.LastUpdated
-	} else {
-		// Fallback to local time with buffer to account for potential clock skew
-		nextSyncTime = queryStartTime.Add(-clockSkewBuffer).Format(time.RFC3339Nano)
-		slog.WarnContext(ctx, "Bundle meta.lastUpdated not available, using local time with buffer - may cause clock skew issues", logging.FHIRServer(fhirBaseURLRaw))
-	}
-	c.lastUpdateTimes[directoryKey] = nextSyncTime
-
 	return report, nil
+}
+
+// recordSyncTimestamp stores the timestamp used as the _since value for the next incremental sync.
+// It prefers the search result Bundle's meta.lastUpdated (the FHIR server's own clock, avoiding
+// skew) and falls back to the local query start time minus a buffer.
+func (c *Component) recordSyncTimestamp(ctx context.Context, run *syncRun) {
+	var nextSyncTime string
+	if run.firstSearchSet.Meta != nil && run.firstSearchSet.Meta.LastUpdated != nil {
+		nextSyncTime = *run.firstSearchSet.Meta.LastUpdated
+	} else {
+		nextSyncTime = run.queryStart.Add(-clockSkewBuffer).Format(time.RFC3339Nano)
+		slog.WarnContext(ctx, "Bundle meta.lastUpdated not available, using local time with buffer - may cause clock skew issues", logging.FHIRServer(run.fhirBaseURL))
+	}
+	c.lastUpdateTimes[run.key()] = nextSyncTime
 }
 
 // queryFHIR performs a FHIR search query with pagination and returns all matching entries.
@@ -663,58 +617,60 @@ func (c *Component) queryAllResourceTypes(ctx context.Context, fhirClient fhircl
 	return entries, firstSearchSet, nil
 }
 
-// checkForURAIdentifierChanges detects if any Organization's URA identifier has changed between history versions
+// noURASentinel marks "this Organization version had no URA identifier" in the set of URA values
+// tracked per organization, so that gaining or losing a URA counts as a change.
+const noURASentinel = ""
+
+// checkForURAIdentifierChanges detects if any Organization's URA identifier has changed between
+// history versions. An organization whose history shows more than one distinct URA value — counting
+// "no URA" (noURASentinel) as a distinct value — has a changed URA identifier.
 func checkForURAIdentifierChanges(entries []fhir.BundleEntry) bool {
-	// Map to track URA identifiers per Organization ID
-	// We use empty string "" as a marker for "no URA identifier present"
-	orgURAMap := make(map[string]map[string]bool) // orgID -> set of URA values (or "" for no URA)
+	uraValuesByOrg := make(map[string]map[string]bool) // orgID -> set of URA values seen across versions
 
 	for _, entry := range entries {
 		if entry.Resource == nil {
 			continue
 		}
-
-		// Try to unmarshal as Organization
 		var org fhir.Organization
 		if err := json.Unmarshal(entry.Resource, &org); err != nil {
 			continue // Not an Organization, skip
 		}
-
 		if org.Id == nil {
 			continue
 		}
 
-		orgID := *org.Id
-
-		// Extract URA identifiers
-		uraIdentifiers := libfhir.FilterIdentifiersBySystem(org.Identifier, coding.URANamingSystem)
-
-		// Initialize map for this org if needed
-		if orgURAMap[orgID] == nil {
-			orgURAMap[orgID] = make(map[string]bool)
+		seen := uraValuesByOrg[*org.Id]
+		if seen == nil {
+			seen = make(map[string]bool)
+			uraValuesByOrg[*org.Id] = seen
 		}
-
-		// Track all URA values seen for this organization
-		if len(uraIdentifiers) == 0 {
-			// No URA identifier - mark with empty string
-			orgURAMap[orgID][""] = true
-		} else {
-			for _, ura := range uraIdentifiers {
-				if ura.Value != nil {
-					orgURAMap[orgID][*ura.Value] = true
-				}
-			}
+		for _, value := range organizationURAValues(org) {
+			seen[value] = true
 		}
 	}
 
-	// Check if any organization has multiple different URA values (including presence/absence changes)
-	for _, uraSet := range orgURAMap {
-		if len(uraSet) > 1 {
-			return true // Found an organization with changed URA identifier
+	for _, values := range uraValuesByOrg {
+		if len(values) > 1 {
+			return true
 		}
 	}
-
 	return false
+}
+
+// organizationURAValues returns the organization's URA identifier values, or a single
+// noURASentinel entry when it has no URA identifier at all.
+func organizationURAValues(org fhir.Organization) []string {
+	uraIdentifiers := libfhir.FilterIdentifiersBySystem(org.Identifier, coding.URANamingSystem)
+	if len(uraIdentifiers) == 0 {
+		return []string{noURASentinel}
+	}
+	var values []string
+	for _, ura := range uraIdentifiers {
+		if ura.Value != nil {
+			values = append(values, *ura.Value)
+		}
+	}
+	return values
 }
 
 func (c *Component) ensureParentOrganizationsMap(ctx context.Context, fhirBaseURLRaw string, remoteAdminDirectoryFHIRClient fhirclient.Client, authoritativeUra string) (parentOrganizationMap, error) {

--- a/component/mcsd/component.go
+++ b/component/mcsd/component.go
@@ -64,9 +64,9 @@ func makeDirectoryKey(fhirBaseURL, authoritativeUra string) string {
 //   - The organization's mcsd-directory-endpoint must be discoverable through the root mCSD Directory.'
 //
 // A root directory may be marked as 'trusted' (DirectoryConfig.Trusted), which skips the per-resource
-// validation described above. This is intended for directories the operator controls or
-// otherwise trusts (e.g. the LRZA). Trust does not affect sync cadence — incremental sync via _since
-// still applies. Directories discovered from a trusted root are always registered as untrusted.
+// validation described above. This is intended for directories that are government-controlled or otherwise trusted
+// (e.g. the LRZA). Trust does not affect sync cadence — incremental sync via _since still applies.
+// Directories discovered from a trusted root are always registered as untrusted.
 type Component struct {
 	config            Config
 	fhirAdminClientFn func(baseURL *url.URL) fhirclient.Client

--- a/component/mcsd/component_test.go
+++ b/component/mcsd/component_test.go
@@ -795,7 +795,7 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 		})
 		component, err := New(DefaultConfig())
 		require.NoError(t, err)
-		report, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization"}, false, "")
+		report, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization"}, false, "", false)
 		require.NoError(t, err)
 		require.NotNil(t, report)
 		require.Len(t, report.Warnings, 1)
@@ -834,7 +834,7 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 			return &test.StubFHIRClient{Error: errors.New("unknown URL")}
 		}
 
-		report, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization", "Endpoint"}, false, "")
+		report, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization", "Endpoint"}, false, "", false)
 
 		require.NoError(t, err)
 		require.Empty(t, report.Errors, "Should not have errors after deduplication")
@@ -993,7 +993,7 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 		}
 
 		// First update - should discover and register the Endpoint
-		report1, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Endpoint", "Organization"}, true, "")
+		report1, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Endpoint", "Organization"}, true, "", false)
 		require.NoError(t, err)
 		require.Empty(t, report1.Errors)
 		require.Equal(t, 1, report1.CountCreated, "Should have created 1 Endpoint")
@@ -1017,7 +1017,7 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 		assert.Equal(t, "http://test.example.org/fhir/Endpoint/test-endpoint", registeredFullUrl, "Registered Endpoint should have fullUrl from Bundle entry")
 
 		// Second update - should process DELETE and unregister the Endpoint
-		report2, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Endpoint", "Organization"}, true, "")
+		report2, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Endpoint", "Organization"}, true, "", false)
 		require.NoError(t, err)
 		require.Empty(t, report2.Errors)
 
@@ -1101,7 +1101,7 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 
 		// Call updateFromDirectory with only Organization and Endpoint
 		allowedTypes := []string{"Organization", "Endpoint"}
-		report, err := component.updateFromDirectory(ctx, server.URL+"/fhir", allowedTypes, false, "")
+		report, err := component.updateFromDirectory(ctx, server.URL+"/fhir", allowedTypes, false, "", false)
 
 		require.NoError(t, err)
 		require.Empty(t, report.Errors)
@@ -1269,7 +1269,7 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 		}
 
 		// Register the root directory (which will query using rootDirectoryResourceTypes: Organization, Endpoint)
-		err = component.registerAdministrationDirectory(ctx, server.URL+"/fhir", rootDirectoryResourceTypes, true, "", "")
+		err = component.registerAdministrationDirectory(ctx, server.URL+"/fhir", rootDirectoryResourceTypes, true, "", "", false)
 		require.NoError(t, err)
 
 		// First update should discover the endpoint from root directory and immediately query it
@@ -1346,7 +1346,7 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		component, err := New(config)
 		require.NoError(t, err)
 
-		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir", []string{"Organization"}, false, "", "")
+		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir", []string{"Organization"}, false, "", "", false)
 
 		require.NoError(t, err, "Should not error when URL is excluded, just skip registration")
 		assert.Len(t, component.administrationDirectories, 0, "No directories should be registered")
@@ -1361,7 +1361,7 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to register with trailing slash - should still be excluded
-		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir/", []string{"Organization"}, false, "", "")
+		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir/", []string{"Organization"}, false, "", "", false)
 
 		require.NoError(t, err, "Should not error when URL is excluded, just skip registration")
 		assert.Len(t, component.administrationDirectories, 0, "No directories should be registered")
@@ -1376,7 +1376,7 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to register without trailing slash - should still be excluded due to trimming
-		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir", []string{"Organization"}, false, "", "")
+		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir", []string{"Organization"}, false, "", "", false)
 
 		require.NoError(t, err, "Should not error when URL is excluded, just skip registration")
 		assert.Len(t, component.administrationDirectories, 0, "No directories should be registered")
@@ -1390,7 +1390,7 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		component, err := New(config)
 		require.NoError(t, err)
 
-		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir/", []string{"Organization"}, false, "", "")
+		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir/", []string{"Organization"}, false, "", "", false)
 
 		require.NoError(t, err, "Should not error when URL is excluded, just skip registration")
 		assert.Len(t, component.administrationDirectories, 0, "No directories should be registered")
@@ -1404,7 +1404,7 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		component, err := New(config)
 		require.NoError(t, err)
 
-		err = component.registerAdministrationDirectory(context.Background(), "http://allowed.com/fhir", []string{"Organization"}, false, "", "")
+		err = component.registerAdministrationDirectory(context.Background(), "http://allowed.com/fhir", []string{"Organization"}, false, "", "", false)
 
 		require.NoError(t, err)
 		assert.Len(t, component.administrationDirectories, 1, "Directory should be registered")
@@ -1424,7 +1424,7 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to register the same URL as admin directory - should be excluded
-		err = component.registerAdministrationDirectory(context.Background(), ownFHIRBaseURL, []string{"Organization"}, true, "", "")
+		err = component.registerAdministrationDirectory(context.Background(), ownFHIRBaseURL, []string{"Organization"}, true, "", "", false)
 
 		require.NoError(t, err, "Should not error when URL is excluded, just skip registration")
 		assert.Len(t, component.administrationDirectories, 0, "Own directory should not be registered as admin directory")
@@ -1441,12 +1441,12 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try to register excluded directories
-		err1 := component.registerAdministrationDirectory(context.Background(), "http://excluded1.com/fhir", []string{"Organization"}, false, "", "")
-		err2 := component.registerAdministrationDirectory(context.Background(), "http://excluded2.com/fhir", []string{"Organization"}, false, "", "")
-		err3 := component.registerAdministrationDirectory(context.Background(), "http://excluded3.com/fhir", []string{"Organization"}, false, "", "")
+		err1 := component.registerAdministrationDirectory(context.Background(), "http://excluded1.com/fhir", []string{"Organization"}, false, "", "", false)
+		err2 := component.registerAdministrationDirectory(context.Background(), "http://excluded2.com/fhir", []string{"Organization"}, false, "", "", false)
+		err3 := component.registerAdministrationDirectory(context.Background(), "http://excluded3.com/fhir", []string{"Organization"}, false, "", "", false)
 
 		// Register an allowed directory
-		err4 := component.registerAdministrationDirectory(context.Background(), "http://allowed.com/fhir", []string{"Organization"}, false, "", "")
+		err4 := component.registerAdministrationDirectory(context.Background(), "http://allowed.com/fhir", []string{"Organization"}, false, "", "", false)
 
 		require.NoError(t, err1, "Should not error when URL is excluded, just skip registration")
 		require.NoError(t, err2, "Should not error when URL is excluded, just skip registration")
@@ -1461,7 +1461,7 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		component, err := New(config)
 		require.NoError(t, err)
 
-		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir", []string{"Organization"}, false, "", "")
+		err = component.registerAdministrationDirectory(context.Background(), "http://example.com/fhir", []string{"Organization"}, false, "", "", false)
 
 		require.NoError(t, err)
 		assert.Len(t, component.administrationDirectories, 1, "Directory should be registered when exclusion list is empty")
@@ -1476,7 +1476,7 @@ func TestComponent_registerAdministrationDirectory(t *testing.T) {
 		require.NoError(t, err)
 
 		// Invalid URL should return error, not silently skip
-		err = component.registerAdministrationDirectory(context.Background(), "not-a-valid-url", []string{"Organization"}, false, "", "")
+		err = component.registerAdministrationDirectory(context.Background(), "not-a-valid-url", []string{"Organization"}, false, "", "", false)
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid FHIR base URL")

--- a/component/mcsd/component_test.go
+++ b/component/mcsd/component_test.go
@@ -1312,6 +1312,152 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 	})
 }
 
+func TestComponent_updateFromDirectory_trusted(t *testing.T) {
+	ctx := context.Background()
+
+	emptyHistoryBundle := `{"resourceType": "Bundle", "type": "history", "entry": []}`
+	emptySearchsetBundle := `{"resourceType": "Bundle", "type": "searchset", "entry": []}`
+
+	makeComponent := func(t *testing.T, server *httptest.Server) (*Component, *test.StubFHIRClient) {
+		capturingClient := &test.StubFHIRClient{}
+		config := DefaultConfig()
+		config.QueryDirectory = DirectoryConfig{FHIRBaseURL: "http://example.com/local/fhir"}
+		component, err := New(config)
+		require.NoError(t, err)
+		component.fhirQueryClient = capturingClient
+		component.fhirAdminClientFn = func(baseURL *url.URL) fhirclient.Client {
+			if baseURL.String() == server.URL+"/fhir" {
+				return fhirclient.New(baseURL, http.DefaultClient, &fhirclient.Config{UsePostSearch: false})
+			}
+			return capturingClient
+		}
+		return component, capturingClient
+	}
+
+	t.Run("bypasses per-resource validation when trusted", func(t *testing.T) {
+		// Organization with no URA identifier and no partOf reference.
+		// Untrusted validation rejects this; trusted accepts it.
+		spoofedOrgHistoryBundle := `{
+			"resourceType": "Bundle",
+			"type": "history",
+			"entry": [{
+				"fullUrl": "http://remote.example.org/fhir/Organization/spoofed",
+				"resource": {
+					"resourceType": "Organization",
+					"id": "spoofed",
+					"name": "Spoofed Org",
+					"active": true
+				},
+				"request": {"method": "POST", "url": "Organization/spoofed"}
+			}]
+		}`
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/fhir/Organization/_history", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(spoofedOrgHistoryBundle))
+		})
+		mux.HandleFunc("/fhir/Organization", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(emptySearchsetBundle))
+		})
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		// Untrusted: spoofed Organization rejected, no resources synced.
+		c1, client1 := makeComponent(t, server)
+		report, err := c1.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization"}, false, "", false)
+		require.NoError(t, err)
+		assert.Empty(t, report.Errors)
+		require.Len(t, report.Warnings, 1, "untrusted should reject spoofed Organization")
+		assert.Empty(t, client1.CreatedResources["Organization"])
+		assert.Equal(t, 0, report.CountCreated)
+
+		// Trusted: spoofed Organization accepted and synced.
+		c2, client2 := makeComponent(t, server)
+		report, err = c2.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization"}, false, "", true)
+		require.NoError(t, err)
+		assert.Empty(t, report.Errors)
+		assert.Empty(t, report.Warnings, "trusted should accept spoofed Organization")
+		assert.Len(t, client2.CreatedResources["Organization"], 1)
+		assert.Equal(t, 1, report.CountCreated)
+	})
+
+	t.Run("skips parent organization query when trusted and not discovering", func(t *testing.T) {
+		var orgQueryCount int
+		var mu sync.Mutex
+		mux := http.NewServeMux()
+		mux.HandleFunc("/fhir/Organization/_history", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(emptyHistoryBundle))
+		})
+		mux.HandleFunc("/fhir/Organization", func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			orgQueryCount++
+			mu.Unlock()
+			_, _ = w.Write([]byte(emptySearchsetBundle))
+		})
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		c, _ := makeComponent(t, server)
+		_, err := c.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization"}, false, "", true)
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Equal(t, 0, orgQueryCount, "trusted+!discover should not query parent organizations")
+	})
+
+	t.Run("still uses _since for incremental sync when trusted", func(t *testing.T) {
+		// _since is stripped for Organization queries (see queryAllResourceTypes),
+		// so use Endpoint to verify incremental sync.
+		validEndpointHistoryBundle := `{
+			"resourceType": "Bundle",
+			"type": "history",
+			"meta": {"lastUpdated": "2025-01-01T00:00:00Z"},
+			"entry": [{
+				"fullUrl": "http://remote.example.org/fhir/Endpoint/ep1",
+				"resource": {
+					"resourceType": "Endpoint",
+					"id": "ep1",
+					"status": "active",
+					"address": "https://example.com/fhir",
+					"connectionType": {
+						"system": "http://terminology.hl7.org/CodeSystem/endpoint-connection-type",
+						"code": "hl7-fhir-rest"
+					},
+					"payloadType": [{
+						"coding": [{"system": "x", "code": "y"}]
+					}]
+				},
+				"request": {"method": "POST", "url": "Endpoint/ep1"}
+			}]
+		}`
+
+		var sinceParams []string
+		var mu sync.Mutex
+		mux := http.NewServeMux()
+		mux.HandleFunc("/fhir/Endpoint/_history", func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			sinceParams = append(sinceParams, r.URL.Query().Get("_since"))
+			mu.Unlock()
+			_, _ = w.Write([]byte(validEndpointHistoryBundle))
+		})
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		c, _ := makeComponent(t, server)
+		_, err := c.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Endpoint"}, false, "", true)
+		require.NoError(t, err)
+		_, err = c.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Endpoint"}, false, "", true)
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Len(t, sinceParams, 2)
+		assert.Empty(t, sinceParams[0], "first update should not include _since")
+		assert.NotEmpty(t, sinceParams[1], "second update should include _since (trusted does not affect sync cadence)")
+	})
+}
+
 func startMockServer(t *testing.T, filesToServe map[string]string) *httptest.Server {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)

--- a/component/mcsd/component_test.go
+++ b/component/mcsd/component_test.go
@@ -333,31 +333,39 @@ func TestComponent_incrementalUpdates(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	// First update - should have no _since parameter
+	// Each update queries the root's Endpoint history twice on purpose: the discovery phase
+	// full-scans it (no _since) to register/unregister directories, and the sync phase queries it
+	// again (incremental, with _since once a timestamp is known) to import its mCSD directory
+	// Endpoints into the query directory.
+
+	// First update - neither query has a _since parameter.
 	_, err = component.update(ctx)
 	require.NoError(t, err)
-	require.Len(t, sinceParams, 1, "Should have 1 request")
-	require.Empty(t, sinceParams[0], "First update should not have _since parameter")
+	require.Len(t, sinceParams, 2, "discovery and sync each query the root once")
+	require.Empty(t, sinceParams[0], "discovery does a full scan")
+	require.Empty(t, sinceParams[1], "first sync should not have _since parameter")
 
 	// Verify timestamp was stored
 	lastUpdate, exists := component.lastUpdateTimes[rootDirServer.URL]
 	require.True(t, exists, "Last update time should be stored")
 	require.NotEmpty(t, lastUpdate, "Last update time should not be empty")
 
-	// Second update - should include _since parameter
+	// Second update - discovery still full-scans; sync now includes _since.
 	_, err = component.update(ctx)
 	require.NoError(t, err)
-	require.Len(t, sinceParams, 2, "Should have 2 requests total")
-	require.NotEmpty(t, sinceParams[1], "Second update should include _since parameter")
+	require.Len(t, sinceParams, 4, "two more queries (discovery + sync)")
+	require.Empty(t, sinceParams[2], "discovery always does a full scan")
+	syncSince := sinceParams[3]
+	require.NotEmpty(t, syncSince, "second sync should include _since parameter")
 
 	// Verify _since parameter is a valid RFC3339 timestamp
-	_, err = time.Parse(time.RFC3339, sinceParams[1])
+	_, err = time.Parse(time.RFC3339, syncSince)
 	require.NoError(t, err, "_since parameter should be valid RFC3339 timestamp")
-	_, err = time.Parse(time.RFC3339Nano, sinceParams[1])
+	_, err = time.Parse(time.RFC3339Nano, syncSince)
 	require.NoError(t, err, "_since parameter should be valid RFC3339Nano timestamp")
 
 	// Verify _since parameter matches the stored timestamp
-	require.Equal(t, lastUpdate, sinceParams[1], "_since parameter should match the stored lastUpdate timestamp")
+	require.Equal(t, lastUpdate, syncSince, "_since parameter should match the stored lastUpdate timestamp")
 }
 
 func TestComponent_multipleDirsSameFHIRBaseURL(t *testing.T) {
@@ -785,7 +793,7 @@ func TestGetLastUpdated(t *testing.T) {
 	}
 }
 
-func TestComponent_updateFromDirectory(t *testing.T) {
+func TestComponent_runSyncJob(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("#233: no entry.Request in _history results", func(t *testing.T) {
@@ -795,7 +803,7 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 		})
 		component, err := New(DefaultConfig())
 		require.NoError(t, err)
-		report, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization"}, false, "", false)
+		report, err := component.runSyncJob(ctx, &syncRun{fhirBaseURL: server.URL + "/fhir", allowedTypes: []string{"Organization"}})
 		require.NoError(t, err)
 		require.NotNil(t, report)
 		require.Len(t, report.Warnings, 1)
@@ -834,7 +842,7 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 			return &test.StubFHIRClient{Error: errors.New("unknown URL")}
 		}
 
-		report, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization", "Endpoint"}, false, "", false)
+		report, err := component.runSyncJob(ctx, &syncRun{fhirBaseURL: server.URL + "/fhir", allowedTypes: []string{"Organization", "Endpoint"}})
 
 		require.NoError(t, err)
 		require.Empty(t, report.Errors, "Should not have errors after deduplication")
@@ -927,20 +935,21 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 			}]
 		}`
 
-		// Create a mock server that returns the initial bundle first, then the delete bundle
-		callCount := 0
+		// Mock server returns the initial bundle until the Endpoint is "deleted" upstream, then the
+		// delete bundle. The two-phase update queries this endpoint more than once per cycle
+		// (discovery + sync), so toggle state between cycles with a flag rather than per HTTP call.
+		endpointDeleted := false
 		mux := http.NewServeMux()
 		server := httptest.NewServer(mux)
 		defer server.Close()
 
 		mux.HandleFunc("/fhir/Endpoint/_history", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			if callCount == 0 {
-				w.Write([]byte(initialBundle))
-			} else {
+			if endpointDeleted {
 				w.Write([]byte(deleteBundle))
+			} else {
+				w.Write([]byte(initialBundle))
 			}
-			callCount++
 		})
 		mux.HandleFunc("/fhir/Organization/_history", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
@@ -992,8 +1001,14 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 			return &test.StubFHIRClient{Error: errors.New("unknown URL")}
 		}
 
-		// First update - should discover and register the Endpoint
-		report1, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Endpoint", "Organization"}, true, "", false)
+		rootRun := func() *syncRun {
+			return &syncRun{fhirBaseURL: server.URL + "/fhir", allowedTypes: []string{"Endpoint", "Organization"}, discoverable: true}
+		}
+
+		// First update - discovery registers the Endpoint as an administration directory; sync
+		// imports it (an untrusted discoverable root only imports its mCSD directory Endpoints).
+		_ = component.discover(ctx)
+		report1, err := component.runSyncJob(ctx, rootRun())
 		require.NoError(t, err)
 		require.Empty(t, report1.Errors)
 		require.Equal(t, 1, report1.CountCreated, "Should have created 1 Endpoint")
@@ -1016,8 +1031,11 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 		assert.True(t, foundEndpoint, "Endpoint should be registered as administration directory")
 		assert.Equal(t, "http://test.example.org/fhir/Endpoint/test-endpoint", registeredFullUrl, "Registered Endpoint should have fullUrl from Bundle entry")
 
-		// Second update - should process DELETE and unregister the Endpoint
-		report2, err := component.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Endpoint", "Organization"}, true, "", false)
+		// Second update - delete the Endpoint upstream, then discovery unregisters it and sync
+		// processes the DELETE against the query directory.
+		endpointDeleted = true
+		_ = component.discover(ctx)
+		report2, err := component.runSyncJob(ctx, rootRun())
 		require.NoError(t, err)
 		require.Empty(t, report2.Errors)
 
@@ -1101,7 +1119,7 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 
 		// Call updateFromDirectory with only Organization and Endpoint
 		allowedTypes := []string{"Organization", "Endpoint"}
-		report, err := component.updateFromDirectory(ctx, server.URL+"/fhir", allowedTypes, false, "", false)
+		report, err := component.runSyncJob(ctx, &syncRun{fhirBaseURL: server.URL + "/fhir", allowedTypes: allowedTypes})
 
 		require.NoError(t, err)
 		require.Empty(t, report.Errors)
@@ -1312,7 +1330,7 @@ func TestComponent_updateFromDirectory(t *testing.T) {
 	})
 }
 
-func TestComponent_updateFromDirectory_trusted(t *testing.T) {
+func TestComponent_runSyncJob_trusted(t *testing.T) {
 	ctx := context.Background()
 
 	emptyHistoryBundle := `{"resourceType": "Bundle", "type": "history", "entry": []}`
@@ -1364,7 +1382,7 @@ func TestComponent_updateFromDirectory_trusted(t *testing.T) {
 
 		// Untrusted: spoofed Organization rejected, no resources synced.
 		c1, client1 := makeComponent(t, server)
-		report, err := c1.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization"}, false, "", false)
+		report, err := c1.runSyncJob(ctx, &syncRun{fhirBaseURL: server.URL + "/fhir", allowedTypes: []string{"Organization"}})
 		require.NoError(t, err)
 		assert.Empty(t, report.Errors)
 		require.Len(t, report.Warnings, 1, "untrusted should reject spoofed Organization")
@@ -1373,7 +1391,7 @@ func TestComponent_updateFromDirectory_trusted(t *testing.T) {
 
 		// Trusted: spoofed Organization accepted and synced.
 		c2, client2 := makeComponent(t, server)
-		report, err = c2.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization"}, false, "", true)
+		report, err = c2.runSyncJob(ctx, &syncRun{fhirBaseURL: server.URL + "/fhir", allowedTypes: []string{"Organization"}, trusted: true})
 		require.NoError(t, err)
 		assert.Empty(t, report.Errors)
 		assert.Empty(t, report.Warnings, "trusted should accept spoofed Organization")
@@ -1398,7 +1416,7 @@ func TestComponent_updateFromDirectory_trusted(t *testing.T) {
 		defer server.Close()
 
 		c, _ := makeComponent(t, server)
-		_, err := c.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Organization"}, false, "", true)
+		_, err := c.runSyncJob(ctx, &syncRun{fhirBaseURL: server.URL + "/fhir", allowedTypes: []string{"Organization"}, trusted: true})
 		require.NoError(t, err)
 
 		mu.Lock()
@@ -1445,9 +1463,9 @@ func TestComponent_updateFromDirectory_trusted(t *testing.T) {
 		defer server.Close()
 
 		c, _ := makeComponent(t, server)
-		_, err := c.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Endpoint"}, false, "", true)
+		_, err := c.runSyncJob(ctx, &syncRun{fhirBaseURL: server.URL + "/fhir", allowedTypes: []string{"Endpoint"}, trusted: true})
 		require.NoError(t, err)
-		_, err = c.updateFromDirectory(ctx, server.URL+"/fhir", []string{"Endpoint"}, false, "", true)
+		_, err = c.runSyncJob(ctx, &syncRun{fhirBaseURL: server.URL + "/fhir", allowedTypes: []string{"Endpoint"}, trusted: true})
 		require.NoError(t, err)
 
 		mu.Lock()

--- a/component/mcsd/discovery.go
+++ b/component/mcsd/discovery.go
@@ -1,0 +1,203 @@
+package mcsd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/nuts-foundation/nuts-knooppunt/lib/coding"
+	libfhir "github.com/nuts-foundation/nuts-knooppunt/lib/fhirutil"
+	"github.com/nuts-foundation/nuts-knooppunt/lib/logging"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
+)
+
+// discover runs the discovery phase for every discoverable (root) administration directory: it
+// crawls each one to register newly-found mCSD directory endpoints and unregister deleted ones.
+// It only mutates c.administrationDirectories. Warnings/errors are returned keyed by directory so
+// update can merge them into the sync report for the same directory.
+func (c *Component) discover(ctx context.Context) UpdateReport {
+	result := make(UpdateReport)
+
+	// Snapshot the discoverable directories first: discovery appends newly-found directories to the
+	// registry, and those must not be crawled again in the same cycle.
+	var roots []administrationDirectory
+	for _, dir := range c.administrationDirectories {
+		if dir.discover {
+			roots = append(roots, dir)
+		}
+	}
+
+	for _, root := range roots {
+		result[makeDirectoryKey(root.fhirBaseURL, root.authoritativeUra)] = c.discoverFromDirectory(ctx, root)
+	}
+	return result
+}
+
+// discoverFromDirectory crawls a single root directory: it queries Organization and Endpoint
+// history, unregisters administration directories whose Endpoint was deleted, and registers
+// newly-found mCSD directory endpoints. It does a full scan (no _since) — roots are small, and a
+// full scan keeps register/unregister deterministic without tracking a separate sync timestamp.
+//
+// Failures that prevent crawling (bad URL, query error) are logged but not reported here: the sync
+// phase queries the same directory and will surface those errors, so reporting them here too would
+// duplicate them.
+func (c *Component) discoverFromDirectory(ctx context.Context, root administrationDirectory) DirectoryUpdateReport {
+	slog.InfoContext(ctx, "Discovering mCSD Directories from root", logging.FHIRServer(root.fhirBaseURL))
+	var report DirectoryUpdateReport
+
+	baseURL, err := url.Parse(root.fhirBaseURL)
+	if err != nil {
+		slog.WarnContext(ctx, "Skipping discovery: invalid FHIR base URL", logging.FHIRServer(root.fhirBaseURL), logging.Error(err))
+		return report
+	}
+	client := c.fhirAdminClientFn(baseURL)
+
+	searchParams := url.Values{
+		"_count": []string{strconv.Itoa(searchPageSize)},
+	}
+	entries, _, err := c.queryAllResourceTypes(ctx, client, root.resourceTypes, searchParams)
+	if err != nil {
+		slog.WarnContext(ctx, "Skipping discovery: failed to query root directory", logging.FHIRServer(root.fhirBaseURL), logging.Error(err))
+		return report
+	}
+
+	// Unregister administration directories whose backing Endpoint was deleted upstream.
+	c.processEndpointDeletes(ctx, deduplicateHistoryEntries(entries))
+
+	parentOrganizationsMap, err := c.ensureParentOrganizationsMap(ctx, root.fhirBaseURL, client, root.authoritativeUra)
+	if err != nil {
+		slog.WarnContext(ctx, "Skipping endpoint discovery: failed to build parent organization map", logging.FHIRServer(root.fhirBaseURL), logging.Error(err))
+		return report
+	}
+
+	return c.discoverAndRegisterEndpoints(ctx, entries, parentOrganizationsMap, report)
+}
+
+// discoverAndRegisterEndpoints registers every mCSD directory Endpoint referenced by a parent
+// organization (one with a URA identifier) as a new administration directory. Registration failures
+// are recorded as warnings on the report.
+func (c *Component) discoverAndRegisterEndpoints(ctx context.Context, entries []fhir.BundleEntry, parentOrganizationsMap parentOrganizationMap, report DirectoryUpdateReport) DirectoryUpdateReport {
+	for parentOrg := range parentOrganizationsMap {
+		authoritativeUra, ok := parentOrgAuthoritativeURA(parentOrg)
+		if !ok {
+			continue
+		}
+
+		for fullUrl, endpoint := range endpointsReferencedByParent(entries, parentOrg) {
+			if !coding.CodablesIncludesCode(endpoint.PayloadType, coding.PayloadCoding) {
+				continue
+			}
+			slog.DebugContext(ctx, "Discovered mCSD Directory", slog.String("address", endpoint.Address))
+			if err := c.registerAdministrationDirectory(ctx, endpoint.Address, c.directoryResourceTypes, false, fullUrl, authoritativeUra, false); err != nil {
+				report.Warnings = append(report.Warnings, fmt.Sprintf("failed to register discovered mCSD Directory at %s: %s", endpoint.Address, err.Error()))
+			}
+		}
+	}
+	return report
+}
+
+// parentOrgAuthoritativeURA returns the organization's URA identifier value, if it has one.
+func parentOrgAuthoritativeURA(org *fhir.Organization) (string, bool) {
+	uraIdentifiers := libfhir.FilterIdentifiersBySystem(org.Identifier, coding.URANamingSystem)
+	if len(uraIdentifiers) == 0 || uraIdentifiers[0].Value == nil {
+		return "", false
+	}
+	return *uraIdentifiers[0].Value, true
+}
+
+// endpointsReferencedByParent returns the Endpoint resources among the entries that the parent
+// organization references via Organization.endpoint, keyed by their Bundle entry fullUrl.
+func endpointsReferencedByParent(entries []fhir.BundleEntry, parentOrg *fhir.Organization) map[string]*fhir.Endpoint {
+	endpoints := make(map[string]*fhir.Endpoint)
+	if len(parentOrg.Endpoint) == 0 {
+		return endpoints
+	}
+
+	for _, entry := range entries {
+		if entry.Resource == nil || entry.FullUrl == nil {
+			continue
+		}
+		var endpoint fhir.Endpoint
+		if err := json.Unmarshal(entry.Resource, &endpoint); err != nil || endpoint.Id == nil {
+			continue
+		}
+		for _, parentEndpoint := range parentOrg.Endpoint {
+			if parentEndpoint.Reference != nil && *endpoint.Id == extractReferenceID(parentEndpoint.Reference) {
+				endpoints[*entry.FullUrl] = &endpoint
+				break
+			}
+		}
+	}
+	return endpoints
+}
+
+func (c *Component) registerAdministrationDirectory(ctx context.Context, fhirBaseURL string, resourceTypes []string, discover bool, sourceURL string, authoritativeUra string, trusted bool) error {
+	// Must be a valid http or https URL
+	parsedFHIRBaseURL, err := url.Parse(fhirBaseURL)
+	if err != nil {
+		return fmt.Errorf("invalid FHIR base URL (url=%s): %w", fhirBaseURL, err)
+	}
+	parsedFHIRBaseURL.Scheme = strings.ToLower(parsedFHIRBaseURL.Scheme)
+	if (parsedFHIRBaseURL.Scheme != "https" && parsedFHIRBaseURL.Scheme != "http") || parsedFHIRBaseURL.Host == "" {
+		return fmt.Errorf("invalid FHIR base URL (url=%s)", fhirBaseURL)
+	}
+
+	// Check if the URL is in the exclusion list (also trim exclusion list entries for consistent matching)
+	trimmedFHIRBaseURL := strings.TrimRight(fhirBaseURL, "/")
+	for _, excludedURL := range c.config.ExcludeAdminDirectories {
+		if strings.TrimRight(excludedURL, "/") == trimmedFHIRBaseURL {
+			slog.InfoContext(ctx, "Skipping administration directory registration: excluded by configuration", logging.FHIRServer(fhirBaseURL))
+			return nil
+		}
+	}
+
+	exists := slices.ContainsFunc(c.administrationDirectories, func(directory administrationDirectory) bool {
+		return directory.fhirBaseURL == fhirBaseURL && directory.authoritativeUra == authoritativeUra
+	})
+	if exists {
+		return nil
+	}
+	c.administrationDirectories = append(c.administrationDirectories, administrationDirectory{
+		resourceTypes:    resourceTypes,
+		fhirBaseURL:      fhirBaseURL,
+		discover:         discover,
+		trusted:          trusted,
+		sourceURL:        sourceURL,
+		authoritativeUra: authoritativeUra,
+	})
+	slog.InfoContext(ctx, "Registered mCSD Directory", logging.FHIRServer(fhirBaseURL), slog.Bool("discover", discover), slog.Bool("trusted", trusted))
+	return nil
+}
+
+// unregisterAdministrationDirectory removes an administration directory from the list by its fullUrl.
+// This is called when an Endpoint is deleted to prevent it from being fetched in future updates.
+// The fullUrl parameter is the Bundle entry fullUrl that was used when the Endpoint was registered.
+func (c *Component) unregisterAdministrationDirectory(ctx context.Context, fullUrl string) {
+	initialCount := len(c.administrationDirectories)
+	c.administrationDirectories = slices.DeleteFunc(c.administrationDirectories, func(dir administrationDirectory) bool {
+		return dir.sourceURL == fullUrl
+	})
+	if len(c.administrationDirectories) < initialCount {
+		slog.InfoContext(ctx, "Unregistered mCSD Directory after Endpoint deletion", slog.String("full_url", fullUrl))
+	}
+}
+
+// processEndpointDeletes processes DELETE operations for Endpoints and unregisters them from administrationDirectories.
+// This prevents deleted Endpoints from being fetched in future updates, fixing issue #241.
+func (c *Component) processEndpointDeletes(ctx context.Context, entries []fhir.BundleEntry) {
+	for _, entry := range entries {
+		if entry.Request != nil && entry.Request.Method == fhir.HTTPVerbDELETE && entry.FullUrl != nil {
+			parts := strings.Split(entry.Request.Url, "/")
+			if len(parts) >= 2 && parts[0] == "Endpoint" {
+				// Unregister the administration directory using the fullUrl
+				// The fullUrl uniquely identifies the resource that was deleted
+				c.unregisterAdministrationDirectory(ctx, *entry.FullUrl)
+			}
+		}
+	}
+}

--- a/component/mcsd/updater.go
+++ b/component/mcsd/updater.go
@@ -20,12 +20,14 @@ import (
 // buildUpdateTransaction constructs a FHIR Bundle transaction for updating resources.
 // It filters entries based on allowed resource types and sets the source in the resource meta.
 // The function takes a context, a Bundle to populate, a Bundle entry,
-// a slice of allowed resource types, and a flag indicating if this is from a discoverable directory,
-// and the source base URL for conditional references.
+// a slice of allowed resource types, and a flag indicating whether to import only mCSD directory
+// Endpoints, and the source base URL for conditional references.
 //
-// Resources are only synced to the query directory if they come from non-discoverable directories.
-// Discoverable directories are for discovery only and their resources should not be synced.
-func buildUpdateTransaction(ctx context.Context, tx *fhir.Bundle, entry fhir.BundleEntry, validationRules ValidationRules, parentOrganizationMap map[*fhir.Organization][]*fhir.Organization, allHealthcareServices []fhir.HealthcareService, isDiscoverableDirectory bool, sourceBaseURL string) (string, error) {
+// When onlyDirectoryEndpoints is true (an untrusted discoverable root directory), only mCSD
+// directory Endpoints are synced to the query directory; all other resources are skipped. Such a
+// directory is crawled for discovery, and its actual resource data is taken from the validated leaf
+// directories instead. Trusted directories pass false here and are synced in full.
+func buildUpdateTransaction(ctx context.Context, tx *fhir.Bundle, entry fhir.BundleEntry, validationRules ValidationRules, parentOrganizationMap map[*fhir.Organization][]*fhir.Organization, allHealthcareServices []fhir.HealthcareService, onlyDirectoryEndpoints bool, sourceBaseURL string) (string, error) {
 	if entry.FullUrl == nil {
 		return "", errors.New("missing 'fullUrl' field")
 	}
@@ -88,10 +90,11 @@ func buildUpdateTransaction(ctx context.Context, tx *fhir.Bundle, entry fhir.Bun
 		return "", err
 	}
 
-	// Only sync resources from non-discoverable directories to the query directory
-	// Exception: mCSD directory endpoints are synced even from discoverable directories for resilience (e.g. if the root directory is down)
+	// For an untrusted discoverable root we only import mCSD directory Endpoints to the query
+	// directory; the directory's other resources are taken from the validated leaf directories.
+	// (Trusted directories pass onlyDirectoryEndpoints=false and are synced in full.)
 	var doSync = true
-	if isDiscoverableDirectory {
+	if onlyDirectoryEndpoints {
 		doSync = false
 		if resourceType == "Endpoint" {
 			// Check if this is an mCSD directory endpoint

--- a/component/mcsd/validator.go
+++ b/component/mcsd/validator.go
@@ -16,6 +16,8 @@ import (
 type ValidationRules struct {
 	// AllowedResourceTypes is a list of FHIR resource types that are allowed to be created/updated.
 	AllowedResourceTypes []string
+	// Trusted skips per-resource spoofing validation. AllowedResourceTypes is still enforced.
+	Trusted bool
 }
 
 // ValidateParentOrganizations validates all parent organizations in the map.
@@ -43,6 +45,11 @@ func ValidateUpdate(ctx context.Context, rules ValidationRules, resourceJSON []b
 	// Base validation
 	if !slices.Contains(rules.AllowedResourceTypes, resourceType) {
 		return fmt.Errorf("resource type %s not allowed", resourceType)
+	}
+
+	// Trusted directories bypass per-resource validation.
+	if rules.Trusted {
+		return nil
 	}
 
 	switch resourceType {

--- a/config/knooppunt.yml
+++ b/config/knooppunt.yml
@@ -9,6 +9,13 @@ mcsd:
   query:
     fhirbaseurl: "http://localhost:8080/fhir"
 
+  # Administration directories to sync from.
+  # Set `trusted: true` to skip anti-spoofing validation on a directory's contents.
+  # admin:
+  #   example:
+  #     fhirbaseurl: "https://fhir.example.org/fhir"
+  #     trusted: true
+
   # Exclude administration directories from being registered
   # Use this to prevent your own FHIR server from being added as an admin directory
   # This avoids syncing your own resources back to yourself


### PR DESCRIPTION
I was thinking today about how we can make the MCDS component easier to understand. This PR attempts to make a couple of improvements:

- Refactor the main component to be a step by step process, each step acting on the `syncRun` struct that maintains the state for that run.
- The discovery phase is now split into its own file. For now we don't want to discard the ability to use the decentralised model. We see use for it even when the national standard is centralised. However splitting it into its own file gets it out of the way of understanding the simple scenario.

This PR builds upon my earlier draft that implements the trusted flag. So it should work with the new centralised LRZA as well.